### PR TITLE
Fix Otomanguean metadata

### DIFF
--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/cuic1234/tepe1280/sant1437/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/cuic1234/tepe1280/sant1437/md.ini
@@ -3,6 +3,6 @@
 name = Santa María Pápalo
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/cent2266/sila1250/sans1274/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/cent2266/sila1250/sans1274/md.ini
@@ -3,6 +3,8 @@
 name = San Simón Zahuatlán
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.8291
+longitude = -98.00505
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/chay1249/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/chay1249/md.ini
@@ -4,8 +4,8 @@ name = Chayuco Mixtec
 hid = mih
 level = language
 iso639-3 = mih
-latitude = 16.3158
-longitude = -97.8114
+latitude = 16.42
+longitude = -97.83
 macroareas = 
 	North America
 countries = 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/sanj1281/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/sanj1281/md.ini
@@ -4,8 +4,8 @@ name = San Juan Colorado Mixtec
 hid = mjc
 level = language
 iso639-3 = mjc
-latitude = 16.3964
-longitude = -97.9279
+latitude = 16.46073
+longitude = -97.95446
 macroareas = 
 	North America
 countries = 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/tutu1243/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/tutu1243/md.ini
@@ -4,7 +4,7 @@ name = Tututepec Mixtec
 hid = mtu
 level = language
 iso639-3 = mtu
-latitude = 16.154
+latitude = 16.11351
 longitude = -97.5597
 macroareas = 
 	North America

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/tutu1243/sant1441/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/coas1316/east2746/tutu1243/sant1441/md.ini
@@ -3,6 +3,8 @@
 name = Santa María Acatepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 16.76337
+longitude = -97.98945
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/peno1244/sanm1297/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/peno1244/sanm1297/md.ini
@@ -3,6 +3,8 @@
 name = San Mateo Tepantepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.002769
+longitude = -97.032893
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/peno1244/sant1445/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/peno1244/sant1445/md.ini
@@ -3,6 +3,8 @@
 name = Santa María Peñoles
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.07959
+longitude = -97.00272
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/peno1244/sant1446/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/peno1244/sant1446/md.ini
@@ -3,6 +3,8 @@
 name = Santiago Tlazoyaltepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.027396
+longitude = -96.995835
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/tlaz1235/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/east2735/tlaz1235/md.ini
@@ -4,7 +4,7 @@ name = Tlazoyaltepec Mixtec
 hid = mqh
 level = language
 iso639-3 = mqh
-latitude = 17.007
+latitude = 17.02704
 longitude = -96.9783
 macroareas = 
 	North America

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/atla1271/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/atla1271/md.ini
@@ -3,6 +3,8 @@
 name = Atlamajalcingo del Monte
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.311733
+longitude = -98.607579
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/cuat1239/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/cuat1239/md.ini
@@ -3,11 +3,13 @@
 name = Cuatzoquitengo
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q16242050
 	https://en.wikipedia.org/wiki/Cuatzoquitengo_Mixtec
+latitude = 17.288353
+longitude = -98.615523
 
 [identifier]
 multitree = mim-cua

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/md.ini
@@ -4,8 +4,8 @@ name = Alacatlatzala Mixtec
 hid = mim
 level = language
 iso639-3 = mim
-latitude = 17.4944
-longitude = -98.4674
+latitude = 17.25
+longitude = -98.58
 macroareas = 
 	North America
 countries = 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/plan1238/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/plan1238/md.ini
@@ -3,6 +3,8 @@
 name = Plan de Guadalupe
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.217315
+longitude = -97.782602
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/poto1253/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/poto1253/md.ini
@@ -3,6 +3,8 @@
 name = Potoichan
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.42233
+longitude = -98.720093
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/toto1307/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alac1244/toto1307/md.ini
@@ -3,6 +3,8 @@
 name = Tototepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.43238
+longitude = -98.58289
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alco1235/petl1238/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alco1235/petl1238/md.ini
@@ -3,6 +3,8 @@
 name = Petlacalancingo Mixtec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.37597
+longitude = -98.49096
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alco1235/xoch1238/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/alco1235/xoch1238/md.ini
@@ -3,6 +3,8 @@
 name = Xochapa Mixtec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.38134
+longitude = -98.44988
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/metl1238/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/guer1245/metl1238/md.ini
@@ -4,7 +4,7 @@ name = Metlatónoc Mixtec
 hid = mxv
 level = language
 iso639-3 = mxv
-latitude = 17.048
+latitude = 17.1947
 longitude = -98.3514
 macroareas = 
 	North America

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/nort3198/soya1236/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/nort3198/soya1236/md.ini
@@ -4,7 +4,7 @@ name = Soyaltepec Mixtec
 hid = vmq
 level = language
 iso639-3 = vmq
-latitude = 17.556
+latitude = 17.5892
 longitude = -97.1921
 macroareas = 
 	North America

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/nort3199/coat1241/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/nort3199/coat1241/md.ini
@@ -4,8 +4,8 @@ name = Coatzospan Mixtec
 hid = miz
 level = language
 iso639-3 = miz
-latitude = 18.1209
-longitude = -96.6591
+latitude = 18.048748
+longitude = -96.763633
 macroareas = 
 	North America
 countries = 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/sout3179/west2643/coic1238/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/sout3179/west2643/coic1238/md.ini
@@ -3,6 +3,8 @@
 name = Coicoyán
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.27301
+longitude = -98.27588
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/sout3179/west2643/sanj1280/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/sout3179/west2643/sanj1280/md.ini
@@ -3,6 +3,8 @@
 name = San Juan Piñas
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.22264
+longitude = -98.14487
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/sout3179/west2643/sanm1291/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/sout3179/west2643/sanm1291/md.ini
@@ -3,6 +3,8 @@
 name = San Martín Peras
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.35912
+longitude = -98.237249
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/tezo1238/tezo1239/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/tezo1238/tezo1239/md.ini
@@ -3,6 +3,8 @@
 name = Tezoatlán
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.65084
+longitude = -97.809724
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/tezo1238/yucu1251/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/tezo1238/yucu1251/md.ini
@@ -3,6 +3,8 @@
 name = Yucu Ñuti
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.63409
+longitude = -97.89151
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sana1284/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sana1284/md.ini
@@ -3,6 +3,8 @@
 name = San Agustín Tlacotepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.203646
+longitude = -97.51853
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sanc1244/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sanc1244/md.ini
@@ -3,6 +3,8 @@
 name = San Cristóbal Amoltepec Mixtec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.28458
+longitude = -97.5706
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sanm1292/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sanm1292/md.ini
@@ -3,6 +3,8 @@
 name = San Miguel Achiutla Mixtec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.3065
+longitude = -97.48886
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sanm1293/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sanm1293/md.ini
@@ -3,6 +3,8 @@
 name = San Mateo Peñasco Mixtec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.15127
+longitude = -97.53321
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sant1440/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/magd1235/sant1440/md.ini
@@ -3,6 +3,8 @@
 name = Santo Domingo Heundío Mixtec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.252957
+longitude = -97.505399
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/nort2985/mont1271/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/nort2985/mont1271/md.ini
@@ -3,6 +3,8 @@
 name = Monte Verde Mixtec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.533751
+longitude = -97.721489
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/nort2985/yoso1238/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/nort2985/yoso1238/md.ini
@@ -3,6 +3,8 @@
 name = Yosoñama
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.427198
+longitude = -97.772669
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/ocot1243/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/ocot1243/md.ini
@@ -4,8 +4,8 @@ name = Ocotepec Mixtec
 hid = mie
 level = language
 iso639-3 = mie
-latitude = 17.1823
-longitude = -97.751
+latitude = 17.144191
+longitude = -97.763219
 macroareas = 
 	North America
 countries = 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/ocot1243/sant1438/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/ocot1243/sant1438/md.ini
@@ -3,6 +3,8 @@
 name = Santa Catarina Yosonotu
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.020729
+longitude = -97.66201
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanj1282/sant1444/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanj1282/sant1444/md.ini
@@ -3,6 +3,8 @@
 name = Santa Maria Tataltepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.142215
+longitude = -97.394068
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/md.ini
@@ -4,8 +4,8 @@ name = San Miguel El Grande Mixtec
 hid = mig
 level = language
 iso639-3 = mig
-latitude = 17.0777
-longitude = -97.5432
+latitude = 17.046881
+longitude = -97.622482
 macroareas = 
 	North America
 countries = 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sanm1296/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sanm1296/md.ini
@@ -3,6 +3,8 @@
 name = San Miguel Chalcatongo
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.03226
+longitude = -97.57074
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sanp1259/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sanp1259/md.ini
@@ -3,6 +3,8 @@
 name = San Pedro Molinos
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.10495
+longitude = -97.54152
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sant1442/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sant1442/md.ini
@@ -3,6 +3,8 @@
 name = Santa María Yosoyúa
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.11985
+longitude = -97.51553
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sant1443/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sanm1295/sant1443/md.ini
@@ -3,6 +3,8 @@
 name = Santa Catarina Ticuá
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.073317
+longitude = -97.536385
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sout3000/nuyo1238/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sout3000/nuyo1238/md.ini
@@ -3,6 +3,8 @@
 name = Nuyoo
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.0147
+longitude = -97.76674
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sout3000/yucu1249/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/mixt1423/mixt1427/west2824/sout3000/yucu1249/md.ini
@@ -3,6 +3,8 @@
 name = Yucuhiti
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
+latitude = 17.03036
+longitude = -97.782372
 

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/triq1251/chic1273/lagu1250/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/triq1251/chic1273/lagu1250/md.ini
@@ -3,7 +3,7 @@
 name = Laguna
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 
 [altnames]

--- a/languoids/tree/otom1299/east2557/amuz1253/mixt1422/triq1251/chic1273/lagu1250/md.ini
+++ b/languoids/tree/otom1299/east2557/amuz1253/mixt1422/triq1251/chic1273/lagu1250/md.ini
@@ -6,13 +6,6 @@ macroareas =
 	North America
 countries = 
 
-[altnames]
-multitree = 
-	Acoma
-	Acoma-Laguna
-	Laguna
-	Western Keresan
-
 [identifier]
 multitree = kjq-aco
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/coyo1236/sanm1302/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/coyo1236/sanm1302/md.ini
@@ -3,6 +3,6 @@
 name = San Mateo Zoyamazalco Popoloca
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/coyo1236/sanv1243/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/coyo1236/sanv1243/md.ini
@@ -3,6 +3,6 @@
 name = San Vicente Coyotepec Popoloca
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sanf1264/huej1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sanf1264/huej1238/md.ini
@@ -3,6 +3,6 @@
 name = Huejonapan
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sanf1264/sant1453/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sanf1264/sant1453/md.ini
@@ -3,6 +3,6 @@
 name = Santa María Nativitas
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sant1454/ahua1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sant1454/ahua1238/md.ini
@@ -3,6 +3,6 @@
 name = Ahuatempan Popoloca
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sant1454/todo1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/choc1278/popo1294/sant1454/todo1238/md.ini
@@ -3,6 +3,6 @@
 name = Todos Santos Almolonga Popoloca
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sana1287/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sana1287/md.ini
@@ -3,6 +3,6 @@
 name = San Antonio Eloxochitlán Mazatec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sanf1265/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sanf1265/md.ini
@@ -3,6 +3,6 @@
 name = San Francisco Huehuetlán Mazatec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sanl1249/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sanl1249/md.ini
@@ -3,6 +3,6 @@
 name = San Lucas Zoquiapan Mazatec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sanl1250/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sanl1250/md.ini
@@ -3,6 +3,6 @@
 name = San Lorenzo Cuanecuiltitla Mazatec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sans1275/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sans1275/md.ini
@@ -3,6 +3,6 @@
 name = San San Jerónimo Mazatec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sant1455/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sant1455/md.ini
@@ -3,6 +3,6 @@
 name = Santa Cruz Ocopetatillo Mazatec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sant1456/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1307/sanj1286/sant1456/md.ini
@@ -3,6 +3,6 @@
 name = Santa Ana Ateixtlahuaca Mazatec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/huau1238/sanm1303/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/huau1238/sanm1303/md.ini
@@ -3,6 +3,6 @@
 name = San Mateo
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/huau1238/sanm1304/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/huau1238/sanm1304/md.ini
@@ -3,6 +3,6 @@
 name = San Miguel
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/maza1296/loma1263/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/maza1296/loma1263/md.ini
@@ -3,6 +3,6 @@
 name = Loma Grande
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/maza1296/zoya1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/popo1293/maza1295/maza1309/maza1296/zoya1238/md.ini
@@ -3,6 +3,6 @@
 name = Zoyaltitla
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/chat1268/core1263/coas1314/east2736/west2644/pani1261/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/chat1268/core1263/coas1314/east2736/west2644/pani1261/md.ini
@@ -3,6 +3,6 @@
 name = Panixtlahuaca Chatino
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/chat1268/core1263/coas1314/east2736/west2644/sanj1283/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/chat1268/core1263/coas1314/east2736/west2644/sanj1283/md.ini
@@ -3,6 +3,6 @@
 name = San Juan Quiahije Chatino
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/chat1268/core1263/coas1314/east2736/west2644/yait1239/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/chat1268/core1263/coas1314/east2736/west2644/yait1239/md.ini
@@ -3,6 +3,6 @@
 name = Yaitepec Chatino
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/mitl1236/sant1449/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/mitl1236/sant1449/md.ini
@@ -3,6 +3,6 @@
 name = Santiago Matatlán Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sanj1284/jali1244/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sanj1284/jali1244/md.ini
@@ -3,6 +3,6 @@
 name = Jalieza Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sanj1284/sanm1299/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sanj1284/sanm1299/md.ini
@@ -3,6 +3,6 @@
 name = San Martín Tilcajete Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sanj1284/teot1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sanj1284/teot1238/md.ini
@@ -3,6 +3,6 @@
 name = Teotitlán del Valle Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sant1447/zaac1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/cent2146/sant1447/zaac1238/md.ini
@@ -3,6 +3,6 @@
 name = Zaachila
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/cajo1238/nucl1670/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/cajo1238/nucl1670/md.ini
@@ -3,6 +3,6 @@
 name = Nuclear Cajonos Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/cajo1238/yaga1261/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/cajo1238/yaga1261/md.ini
@@ -3,6 +3,6 @@
 name = Yaganiza-Xagacía Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/zoog1238/tabe1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/zoog1238/tabe1238/md.ini
@@ -3,6 +3,6 @@
 name = Tabehua
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/zoog1238/yali1256/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/zoog1238/yali1256/md.ini
@@ -3,6 +3,6 @@
 name = Yalina
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/zoog1238/zoog1239/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/nort2987/zoog1238/zoog1239/md.ini
@@ -3,6 +3,6 @@
 name = Zoogocho
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/loxi1235/cand1249/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/loxi1235/cand1249/md.ini
@@ -3,6 +3,6 @@
 name = Candelaria Loxicha Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/loxi1235/sana1285/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/loxi1235/sana1285/md.ini
@@ -3,6 +3,6 @@
 name = San Agustín Loxicha Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/ozol1235/sang1340/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/ozol1235/sang1340/md.ini
@@ -3,6 +3,6 @@
 name = San Gregorio Ozolotepec Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/ozol1235/sanm1300/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/miah1236/ozol1235/sanm1300/md.ini
@@ -3,6 +3,6 @@
 name = San Marcial Ozolotepec Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/mixt1428/quio1241/quie1238/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/mixt1428/quio1241/quie1238/md.ini
@@ -3,6 +3,6 @@
 name = Quierí Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/mixt1428/quio1241/quio1242/md.ini
+++ b/languoids/tree/otom1299/east2557/popo1292/zapo1436/zapo1437/nucl1765/core1259/sout3003/mixt1428/quio1241/quio1242/md.ini
@@ -3,6 +3,6 @@
 name = Quioquitani Zapotec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/otop1241/chin1484/chin1485/ozum1235/ayot1238/md.ini
+++ b/languoids/tree/otom1299/west2783/otop1241/chin1484/chin1485/ozum1235/ayot1238/md.ini
@@ -3,6 +3,6 @@
 name = Ayotzintepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/otop1241/chin1484/chin1488/quio1240/yolo1240/md.ini
+++ b/languoids/tree/otom1299/west2783/otop1241/chin1484/chin1488/quio1240/yolo1240/md.ini
@@ -3,6 +3,6 @@
 name = Yolox Chinanteco
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/maza1293/cent2144/atla1270/md.ini
+++ b/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/maza1293/cent2144/atla1270/md.ini
@@ -3,6 +3,6 @@
 name = Atlacomulco-Temascalcingo
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/maza1293/cent2144/sanm1290/md.ini
+++ b/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/maza1293/cent2144/sanm1290/md.ini
@@ -3,6 +3,6 @@
 name = San Miguel Tenoxtitlán
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/maza1293/cent2144/sant1435/md.ini
+++ b/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/maza1293/cent2144/sant1435/md.ini
@@ -3,6 +3,6 @@
 name = Santa María Citendejé-Banos
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/sout3168/esta1236/sanf1263/md.ini
+++ b/languoids/tree/otom1299/west2783/otop1241/otop1242/otom1297/sout3168/esta1236/sanf1263/md.ini
@@ -3,6 +3,6 @@
 name = San Felipe Santiago Otomí
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/diri1255/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/diri1255/md.ini
@@ -3,6 +3,6 @@
 name = Diria
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/nagr1240/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/nagr1240/md.ini
@@ -3,6 +3,6 @@
 name = Nagrandan
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/nico1263/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/nico1263/md.ini
@@ -3,6 +3,6 @@
 name = Nicoya
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/nucl1669/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/nucl1669/md.ini
@@ -3,6 +3,6 @@
 name = Jinotepe-Nindirí
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/oris1240/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/oris1240/md.ini
@@ -3,6 +3,6 @@
 name = Orisi
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/orot1239/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/mang1426/moni1237/orot1239/md.ini
@@ -3,6 +3,6 @@
 name = Orotiña
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 

--- a/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/acat1239/acat1240/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/acat1239/acat1240/md.ini
@@ -3,7 +3,7 @@
 name = Acatepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 
 [altnames]

--- a/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/acat1239/plat1255/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/acat1239/plat1255/md.ini
@@ -3,7 +3,7 @@
 name = Platanillo
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 
 [altnames]

--- a/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/acat1239/zapo1435/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/acat1239/zapo1435/md.ini
@@ -3,7 +3,7 @@
 name = Zapotitlán Tablas
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 
 [altnames]

--- a/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/mali1285/huiz1244/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/mali1285/huiz1244/md.ini
@@ -3,7 +3,7 @@
 name = Huizapula-Zapotitlán Tablas
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 
 [altnames]

--- a/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/mali1285/mali1286/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/mali1285/mali1286/md.ini
@@ -3,7 +3,7 @@
 name = Malinaltepec
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 
 [altnames]

--- a/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/mali1285/zila1239/md.ini
+++ b/languoids/tree/otom1299/west2783/tlap1252/subt1249/meph1234/mali1285/zila1239/md.ini
@@ -3,7 +3,7 @@
 name = Zilacayotitlán
 level = dialect
 macroareas = 
-	South America
+	North America
 countries = 
 
 [altnames]


### PR DESCRIPTION
- Assign macroarea North America to all Otomanguean dialects.
- Update/assign coordinates (following data from @SAuderset) to Mixtec languoids.

closes #435