### PR TITLE
remove non-matching macroareas from dialects

### DIFF
--- a/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/coas1310/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/coas1310/md.ini
@@ -3,7 +3,6 @@
 name = Coastal Tihaamah
 level = dialect
 macroareas = 
-	Africa
 countries = 
 
 [altnames]

--- a/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/nort3136/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/nort3136/md.ini
@@ -3,7 +3,6 @@
 name = North Hijazi
 level = dialect
 macroareas = 
-	Africa
 countries = 
 
 [altnames]

--- a/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/sout3118/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/sout3118/md.ini
@@ -3,7 +3,6 @@
 name = South Hijazi
 level = dialect
 macroareas = 
-	Africa
 countries = 
 
 [altnames]

--- a/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/vall1257/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/hija1235/vall1257/md.ini
@@ -3,7 +3,6 @@
 name = Valley Tihaamah
 level = dialect
 macroareas = 
-	Africa
 countries = 
 
 [altnames]

--- a/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/taiz1242/aden1241/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/taiz1242/aden1241/md.ini
@@ -3,7 +3,6 @@
 name = Adeni
 level = dialect
 macroareas = 
-	Africa
 countries = 
 
 [altnames]

--- a/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/taiz1242/taiz1243/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/arab1393/taiz1242/taiz1243/md.ini
@@ -3,7 +3,6 @@
 name = Ta'izzi
 level = dialect
 macroareas = 
-	Africa
 countries = 
 
 [altnames]

--- a/languoids/tree/araw1281/nort2990/cari1281/isla1279/gari1256/east2562/md.ini
+++ b/languoids/tree/araw1281/nort2990/cari1281/isla1279/gari1256/east2562/md.ini
@@ -3,6 +3,5 @@
 name = Eastern Garifuna
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/araw1281/nort2990/cari1281/isla1279/gari1256/west2649/md.ini
+++ b/languoids/tree/araw1281/nort2990/cari1281/isla1279/gari1256/west2649/md.ini
@@ -3,6 +3,5 @@
 name = Western Garifuna
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/araw1281/nort2990/cari1281/isla1279/isla1278/vinc1241/md.ini
+++ b/languoids/tree/araw1281/nort2990/cari1281/isla1279/isla1278/vinc1241/md.ini
@@ -3,6 +3,5 @@
 name = Vincentian
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/bush1250/kian1236/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/bush1250/kian1236/md.ini
@@ -3,7 +3,6 @@
 name = Kiantalaotse
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/bets1235/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/bets1235/md.ini
@@ -3,7 +3,6 @@
 name = Betsileo
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/beza1235/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/beza1235/md.ini
@@ -3,7 +3,6 @@
 name = Bezanozano
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/meri1243/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/meri1243/md.ini
@@ -3,7 +3,6 @@
 name = Merina
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q3028646

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/siha1244/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/siha1244/md.ini
@@ -3,7 +3,6 @@
 name = Sihanaka
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/tana1285/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/cent2271/nort3281/nort3212/bara1403/plat1254/tana1285/md.ini
@@ -3,7 +3,6 @@
 name = Tanala
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/nort3207/anta1255/kibu1236/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/nort3196/nort3207/anta1255/kibu1236/md.ini
@@ -3,7 +3,6 @@
 name = Kibushi-Kimaore
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/sout3174/saka1299/masi1268/vezo1235/md.ini
+++ b/languoids/tree/aust1307/mala1545/basa1291/grea1283/sout2919/mala1537/sout3174/saka1299/masi1268/vezo1235/md.ini
@@ -5,7 +5,6 @@ level = dialect
 latitude = -23.34
 longitude = 43.67
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/bedu1242/md.ini
+++ b/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/bedu1242/md.ini
@@ -3,7 +3,6 @@
 name = Beduanda
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/bela1258/md.ini
+++ b/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/bela1258/md.ini
@@ -3,7 +3,6 @@
 name = Belanda
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/bere1250/md.ini
+++ b/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/bere1250/md.ini
@@ -3,7 +3,6 @@
 name = Berembun
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/mant1268/md.ini
+++ b/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/mant1268/md.ini
@@ -3,7 +3,6 @@
 name = Mantra
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/nucl1462/md.ini
+++ b/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/nucl1462/md.ini
@@ -3,6 +3,5 @@
 name = Nuclear Temuan
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/udai1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/mala1536/nort3170/mala1538/nucl1733/sing1270/temu1239/udai1237/md.ini
@@ -3,7 +3,6 @@
 name = Udai
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/moke1241/moke1242/dung1255/md.ini
+++ b/languoids/tree/aust1307/mala1545/moke1241/moke1242/dung1255/md.ini
@@ -3,7 +3,6 @@
 name = Dung
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/moke1241/moke1242/jait1238/md.ini
+++ b/languoids/tree/aust1307/mala1545/moke1241/moke1242/jait1238/md.ini
@@ -3,7 +3,6 @@
 name = Ja-It
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/aust1307/mala1545/moke1241/moke1242/lbee1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/moke1241/moke1242/lbee1237/md.ini
@@ -3,7 +3,6 @@
 name = L'be
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/chib1249/core1252/isth1243/east2569/kuna1280/sanb1242/baya1263/md.ini
+++ b/languoids/tree/chib1249/core1252/isth1243/east2569/kuna1280/sanb1242/baya1263/md.ini
@@ -3,6 +3,5 @@
 name = Bayano
 level = dialect
 macroareas = 
-	North America
 countries = 
 

--- a/languoids/tree/chib1249/core1252/isth1243/east2569/kuna1280/sanb1242/chua1255/md.ini
+++ b/languoids/tree/chib1249/core1252/isth1243/east2569/kuna1280/sanb1242/chua1255/md.ini
@@ -3,6 +3,5 @@
 name = Chuana
 level = dialect
 macroareas = 
-	North America
 countries = 
 

--- a/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/rhin1244/pala1355/penn1240/amis1245/md.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/rhin1244/pala1355/penn1240/amis1245/md.ini
@@ -3,7 +3,6 @@
 name = Amish Pennsylvania German
 level = dialect
 macroareas = 
-	Eurasia
 countries = 
 
 [altnames]

--- a/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/rhin1244/pala1355/penn1240/nona1239/md.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/rhin1244/pala1355/penn1240/nona1239/md.ini
@@ -3,7 +3,6 @@
 name = Non-Amish Pennsylvania German
 level = dialect
 macroareas = 
-	Eurasia
 countries = 
 
 [altnames]

--- a/languoids/tree/indo1319/indo1320/indo1321/biha1245/west2806/bhoj1246/cari1275/sarn1238/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/biha1245/west2806/bhoj1246/cari1275/sarn1238/md.ini
@@ -3,7 +3,6 @@
 name = Sarnami Hindustani
 level = dialect
 macroareas = 
-	Eurasia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q2519308

--- a/languoids/tree/indo1319/indo1320/indo1321/biha1245/west2806/bhoj1246/cari1275/trin1268/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/biha1245/west2806/bhoj1246/cari1275/trin1268/md.ini
@@ -3,7 +3,6 @@
 name = Trinidad Bhojpuri
 level = dialect
 macroareas = 
-	Eurasia
 countries = 
 
 [altnames]

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/caju1236/bigw1239/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/caju1236/bigw1239/md.ini
@@ -3,6 +3,5 @@
 name = Big Woods French
 level = dialect
 macroareas = 
-	Eurasia
 countries = 
 

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/caju1236/mars1252/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/caju1236/mars1252/md.ini
@@ -3,6 +3,5 @@
 name = Marsh French
 level = dialect
 macroareas = 
-	Eurasia
 countries = 
 

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/caju1236/prai1242/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/caju1236/prai1242/md.ini
@@ -3,6 +3,5 @@
 name = Prairie French
 level = dialect
 macroareas = 
-	Eurasia
 countries = 
 

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/hait1244/fabl1238/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/hait1244/fabl1238/md.ini
@@ -3,7 +3,6 @@
 name = Fablas
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q12890547

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/hait1244/plat1258/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/hait1244/plat1258/md.ini
@@ -3,7 +3,6 @@
 name = Plateau Haitian Creole
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/guad1242/mari1444/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/guad1242/mari1444/md.ini
@@ -3,7 +3,6 @@
 name = Marie Galante Creole French
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/guad1242/stba1239/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/guad1242/stba1239/md.ini
@@ -3,7 +3,6 @@
 name = St. Barth Creole French
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/luci1234/sain1246/pato1243/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/luci1234/sain1246/pato1243/md.ini
@@ -3,7 +3,6 @@
 name = Patois
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/luci1234/sain1246/patw1249/md.ini
+++ b/languoids/tree/indo1319/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/less1242/luci1234/sain1246/patw1249/md.ini
@@ -3,6 +3,5 @@
 name = Patwa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/hokk1249/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/hokk1249/md.ini
@@ -3,7 +3,6 @@
 name = Hokkaidō
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://en.wikipedia.org/wiki/Hokkaido_dialects

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/chib1248/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/chib1248/md.ini
@@ -3,7 +3,6 @@
 name = Chiba
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11406064

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/ibar1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/ibar1242/md.ini
@@ -3,7 +3,6 @@
 name = Ibaraki
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q5983728

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/md.ini
@@ -3,7 +3,6 @@
 name = Eastern Kantō
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11528659

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/toch1258/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/east2527/toch1258/md.ini
@@ -3,7 +3,6 @@
 name = Tochigi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11535178

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/md.ini
@@ -3,7 +3,6 @@
 name = Kantō
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q6365634

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/bosh1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/bosh1242/md.ini
@@ -3,7 +3,6 @@
 name = Bōshū
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11496686

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/chic1269/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/chic1269/md.ini
@@ -3,7 +3,6 @@
 name = Chichibu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11596140

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/gunm1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/gunm1237/md.ini
@@ -3,7 +3,6 @@
 name = Gunma
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11609561

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/kana1290/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/kana1290/md.ini
@@ -3,6 +3,5 @@
 name = Kanagawa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/md.ini
@@ -3,7 +3,6 @@
 name = Western Kantō
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11629950

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/tama1337/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/tama1337/md.ini
@@ -3,7 +3,6 @@
 name = Tama (Japonic)
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11430771

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/toky1238/hyoj1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/toky1238/hyoj1237/md.ini
@@ -3,6 +3,5 @@
 name = Hyōjungo
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/toky1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/toky1238/md.ini
@@ -3,7 +3,6 @@
 name = Tōkyō
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://en.wikipedia.org/wiki/Tokyo_dialect

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/toky1238/shit1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/kant1251/west2608/toky1238/shit1242/md.ini
@@ -3,7 +3,6 @@
 name = Shitamachi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11259242

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/md.ini
@@ -3,7 +3,6 @@
 name = Eastern Japanese
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11527182

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/md.ini
@@ -3,7 +3,6 @@
 name = Tōhoku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q3547069

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/akit1240/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/akit1240/md.ini
@@ -3,7 +3,6 @@
 name = Akita
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://en.wikipedia.org/wiki/Akita_dialect

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/md.ini
@@ -3,7 +3,6 @@
 name = Northern Tōhoku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11401375

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/mori1272/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/mori1272/md.ini
@@ -3,7 +3,6 @@
 name = Morioka
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11581393

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/namb1295/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/namb1295/md.ini
@@ -3,7 +3,6 @@
 name = Nambu (Japanese)
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11408543

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/shim1253/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/shim1253/md.ini
@@ -3,7 +3,6 @@
 name = Shimokita
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11360649

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/shon1252/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/shon1252/md.ini
@@ -3,7 +3,6 @@
 name = Shōnai
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11485811

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/tsug1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/nort2934/tsug1237/md.ini
@@ -3,7 +3,6 @@
 name = Tsugaru
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q908025

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/aizu1241/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/aizu1241/md.ini
@@ -3,7 +3,6 @@
 name = Aizu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11381244

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/fuku1243/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/fuku1243/md.ini
@@ -3,7 +3,6 @@
 name = Fukushima
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11593102

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/kese1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/kese1237/md.ini
@@ -3,7 +3,6 @@
 name = Kesen
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q840887

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/md.ini
@@ -3,7 +3,6 @@
 name = Southern Tōhoku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11407706

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/moga1249/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/moga1249/md.ini
@@ -3,7 +3,6 @@
 name = Mogami
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11502199

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/send1240/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/send1240/md.ini
@@ -3,7 +3,6 @@
 name = Sendai
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11378007

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/yama1262/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/yama1262/md.ini
@@ -3,7 +3,6 @@
 name = Yamagata
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q2077307

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/yone1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toho1244/sout2953/yone1237/md.ini
@@ -3,7 +3,6 @@
 name = Yonezawa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11608540

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/joet1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/joet1237/md.ini
@@ -3,7 +3,6 @@
 name = Jōetsu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q22130894

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/md.ini
@@ -3,7 +3,6 @@
 name = Echigo
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11636514

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/naga1406/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/naga1406/md.ini
@@ -3,7 +3,6 @@
 name = Nagaoka
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q4161009

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/niig1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/niig1237/md.ini
@@ -3,7 +3,6 @@
 name = Niigata
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11502947

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/uonu1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/echi1237/uonu1237/md.ini
@@ -3,6 +3,5 @@
 name = Uonuma
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/hida1245/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/hida1245/md.ini
@@ -3,7 +3,6 @@
 name = Hida
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q4161013

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/md.ini
@@ -3,7 +3,6 @@
 name = Gifu-Aichi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q24899133

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mika1255/east2528/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mika1255/east2528/md.ini
@@ -3,6 +3,5 @@
 name = Eastern Mikawa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mika1255/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mika1255/md.ini
@@ -3,7 +3,6 @@
 name = Mikawa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://en.wikipedia.org/wiki/Mikawa_dialect

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mika1255/west2609/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mika1255/west2609/md.ini
@@ -3,6 +3,5 @@
 name = Western Mikawa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mino1244/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/mino1244/md.ini
@@ -3,7 +3,6 @@
 name = Mino
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q4161006

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/owar1237/chit1283/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/owar1237/chit1283/md.ini
@@ -3,7 +3,6 @@
 name = Chita
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11584551

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/owar1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/owar1237/md.ini
@@ -3,7 +3,6 @@
 name = Owari
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11465303

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/owar1237/nago1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/gifu1238/owar1237/nago1242/md.ini
@@ -3,7 +3,6 @@
 name = Nagoya
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://en.wikipedia.org/wiki/Nagoya_dialect

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/md.ini
@@ -3,7 +3,6 @@
 name = Tōkai-Tōsan
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q7862687

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/ensh1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/ensh1237/md.ini
@@ -3,7 +3,6 @@
 name = Enshū
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11642084

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/izuu1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/izuu1237/md.ini
@@ -3,7 +3,6 @@
 name = Izu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11380577

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/md.ini
@@ -3,7 +3,6 @@
 name = Nagano-Yamanashi-Shizuoka
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q24899137

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/chus1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/chus1237/md.ini
@@ -3,6 +3,5 @@
 name = Chūshin
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/hoku1243/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/hoku1243/md.ini
@@ -3,6 +3,5 @@
 name = Hokushin
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/md.ini
@@ -3,7 +3,6 @@
 name = Nagano
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11654322

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/nans1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/nans1238/md.ini
@@ -3,6 +3,5 @@
 name = Nanshin
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/okus1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/okus1237/md.ini
@@ -3,6 +3,5 @@
 name = Okushin
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/tosh1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/naga1408/tosh1237/md.ini
@@ -3,6 +3,5 @@
 name = Tōshin
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/shiz1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/shiz1237/md.ini
@@ -3,7 +3,6 @@
 name = Shizuoka
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q48744198

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/yama1263/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/east2526/toka1245/naga1407/yama1263/md.ini
@@ -3,7 +3,6 @@
 name = Yamanashi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11577750

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/hach1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/hach1238/md.ini
@@ -3,7 +3,6 @@
 name = Hachijō
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q5637049

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1251/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1251/md.ini
@@ -3,7 +3,6 @@
 name = Chikuho-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11602978

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1252/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1252/md.ini
@@ -3,7 +3,6 @@
 name = Chikugo-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11602819

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1252/omut1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1252/omut1237/md.ini
@@ -3,7 +3,6 @@
 name = Ōmuta-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11437781

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1252/yana1269/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/chik1252/yana1269/md.ini
@@ -3,7 +3,6 @@
 name = Yanagawa-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11534280

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/haka1241/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/haka1241/md.ini
@@ -3,7 +3,6 @@
 name = Hakata-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q3125826

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/hita1244/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/hita1244/md.ini
@@ -3,7 +3,6 @@
 name = Hita-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11509915

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/kuma1281/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/kuma1281/md.ini
@@ -3,7 +3,6 @@
 name = Kumamoto-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11568192

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/md.ini
@@ -3,7 +3,6 @@
 name = Hichiku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11254763

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/naga1405/hira1247/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/naga1405/hira1247/md.ini
@@ -3,6 +3,5 @@
 name = Hirado-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/naga1405/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/naga1405/md.ini
@@ -3,7 +3,6 @@
 name = Nagasaki-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11652558

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/naga1405/sase1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/naga1405/sase1237/md.ini
@@ -3,7 +3,6 @@
 name = Sasebo-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11382558

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/saga1265/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/saga1265/md.ini
@@ -3,7 +3,6 @@
 name = Saga-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q4161011

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/tsus1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/hich1237/tsus1237/md.ini
@@ -3,7 +3,6 @@
 name = Tsushima-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q3541681

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/kita1251/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/kita1251/md.ini
@@ -3,7 +3,6 @@
 name = Kitakyūshū-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11401049

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/md.ini
@@ -3,7 +3,6 @@
 name = Hōnichi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q5965236

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/miya1258/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/miya1258/md.ini
@@ -3,7 +3,6 @@
 name = Miyazaki-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11454324

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/oita1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/honi1246/oita1237/md.ini
@@ -3,7 +3,6 @@
 name = Ōita-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q4161004

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/md.ini
@@ -3,7 +3,6 @@
 name = Kyūshū
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q10878817

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/md.ini
@@ -3,7 +3,6 @@
 name = Satsugū
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q3191866

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/moro1291/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/moro1291/md.ini
@@ -3,7 +3,6 @@
 name = Morogata
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11632125

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/osum1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/osum1242/md.ini
@@ -3,6 +3,5 @@
 name = Osumi-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/sats1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/kyus1238/sats1241/sats1242/md.ini
@@ -3,6 +3,5 @@
 name = Satsuma-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/fuku1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/fuku1242/md.ini
@@ -3,7 +3,6 @@
 name = Fukuyama
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11592068

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/hiro1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/hiro1237/md.ini
@@ -3,7 +3,6 @@
 name = Hiroshima
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q3136373

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/iwam1258/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/iwam1258/md.ini
@@ -3,7 +3,6 @@
 name = Iwami
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11587181

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/md.ini
@@ -3,7 +3,6 @@
 name = Chūgoku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q5119018

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/okay1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/okay1237/md.ini
@@ -3,7 +3,6 @@
 name = Okayama
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q3350026

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/taji1247/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/taji1247/md.ini
@@ -3,7 +3,6 @@
 name = Tajima
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11381629

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/tang1357/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/tang1357/md.ini
@@ -3,7 +3,6 @@
 name = Tango
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11368521

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/tott1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/tott1237/md.ini
@@ -3,7 +3,6 @@
 name = Tottori
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11420250

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/yama1261/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/chug1253/yama1261/md.ini
@@ -3,7 +3,6 @@
 name = Yamaguchi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11466825

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/fuku1241/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/fuku1241/md.ini
@@ -3,7 +3,6 @@
 name = Fukui
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q12348069

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/kana1289/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/kana1289/md.ini
@@ -3,7 +3,6 @@
 name = Kanazawa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q17225284

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/md.ini
@@ -3,7 +3,6 @@
 name = Hokuriku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q4161014

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/noto1243/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/noto1243/md.ini
@@ -3,7 +3,6 @@
 name = Noto
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11612029

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/sado1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/sado1237/md.ini
@@ -3,7 +3,6 @@
 name = Sado
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11383301

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/toya1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/hoku1242/toya1237/md.ini
@@ -3,7 +3,6 @@
 name = Toyama
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q17223139

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/bans1249/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/bans1249/md.ini
@@ -3,7 +3,6 @@
 name = Banshū
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://en.wikipedia.org/wiki/Bansh%C5%AB_dialect

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kobe1244/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kobe1244/md.ini
@@ -3,7 +3,6 @@
 name = Kobe (Japonic)
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11590134

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/gion1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/gion1237/md.ini
@@ -3,6 +3,5 @@
 name = Gion
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/gosh1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/gosh1237/md.ini
@@ -3,6 +3,5 @@
 name = Gosho
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/md.ini
@@ -3,7 +3,6 @@
 name = Kyoto
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q10350282

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/muro1241/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/kyot1238/muro1241/md.ini
@@ -3,6 +3,5 @@
 name = Muromachi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/maiz1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/maiz1237/md.ini
@@ -3,7 +3,6 @@
 name = Maizuru
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11613712

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/md.ini
@@ -3,7 +3,6 @@
 name = Kinki
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q1191393

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/igaa1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/igaa1237/md.ini
@@ -3,7 +3,6 @@
 name = Iga
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11380661

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/isee1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/isee1237/md.ini
@@ -3,7 +3,6 @@
 name = Ise
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11379074

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/md.ini
@@ -3,7 +3,6 @@
 name = Mie
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11357700

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/shim1252/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/miee1237/shim1252/md.ini
@@ -3,7 +3,6 @@
 name = Shima
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11490945

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/okuy1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/okuy1237/md.ini
@@ -3,7 +3,6 @@
 name = Oku-yoshino
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q48746988

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/kawa1282/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/kawa1282/md.ini
@@ -3,7 +3,6 @@
 name = Kawachi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11553403

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/md.ini
@@ -3,6 +3,5 @@
 name = Ōsaka
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/semb1241/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/semb1241/md.ini
@@ -3,6 +3,5 @@
 name = Semba
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/sens1241/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/osak1237/sens1241/md.ini
@@ -3,7 +3,6 @@
 name = Senshū
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11554815

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/shig1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/shig1237/md.ini
@@ -3,7 +3,6 @@
 name = Shiga
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11638495

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/waka1278/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/waka1278/md.ini
@@ -3,7 +3,6 @@
 name = Wakasa
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11477419

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/waka1279/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/kink1238/waka1279/md.ini
@@ -3,7 +3,6 @@
 name = Wakayama
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11605045

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/md.ini
@@ -3,7 +3,6 @@
 name = Western Japanese
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11628382

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/hata1244/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/hata1244/md.ini
@@ -3,7 +3,6 @@
 name = Hata-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11481860

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/iyob1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/iyob1237/md.ini
@@ -3,7 +3,6 @@
 name = Iyo-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q6101339

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/kaga1258/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/kaga1258/md.ini
@@ -3,7 +3,6 @@
 name = Kagawa-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q7420744

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/md.ini
@@ -3,7 +3,6 @@
 name = Shikoku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q7496609

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/toku1245/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/shik1243/toku1245/md.ini
@@ -3,7 +3,6 @@
 name = Tokushima-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q11657543

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/umpa1238/izum1237/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/umpa1238/izum1237/md.ini
@@ -3,7 +3,6 @@
 name = Izumo-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q22124007

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/umpa1238/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/umpa1238/md.ini
@@ -3,7 +3,6 @@
 name = Umpaku
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q7881745

--- a/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/umpa1238/yona1240/md.ini
+++ b/languoids/tree/japo1237/japa1256/japa1258/nucl1643/west2607/umpa1238/yona1240/md.ini
@@ -3,6 +3,5 @@
 name = Yonago-ben
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/kika1239/onot1238/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/kika1239/onot1238/md.ini
@@ -3,7 +3,6 @@
 name = Onotsu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/okin1245/okin1246/east2529/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/okin1245/okin1246/east2529/md.ini
@@ -3,7 +3,6 @@
 name = East Oki-No-Erabu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/okin1245/okin1246/west2610/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/okin1245/okin1246/west2610/md.ini
@@ -3,7 +3,6 @@
 name = West Oki-No-Erabu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/okin1245/toku1246/kame1253/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/okin1245/toku1246/kame1253/md.ini
@@ -3,7 +3,6 @@
 name = Kametsu
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/oshi1235/nort2935/naze1238/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/oshi1235/nort2935/naze1238/md.ini
@@ -3,7 +3,6 @@
 name = Naze
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/oshi1235/nort2935/sani1272/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/amam1245/nucl1644/oshi1235/nort2935/sani1272/md.ini
@@ -3,6 +3,5 @@
 name = Sani (Japonic)
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 

--- a/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/kuda1249/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/kuda1249/md.ini
@@ -3,7 +3,6 @@
 name = Kudaka
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/naha1264/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/naha1264/md.ini
@@ -3,7 +3,6 @@
 name = Naha
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/shur1243/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/shur1243/md.ini
@@ -3,7 +3,6 @@
 name = Shuri
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 links = 
 	https://www.wikidata.org/entity/Q47010775

--- a/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/tori1242/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/cent2126/tori1242/md.ini
@@ -3,7 +3,6 @@
 name = Torishima
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/kuni1268/nago1243/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/nort3255/okin1244/kuni1268/nago1243/md.ini
@@ -3,7 +3,6 @@
 name = Nago
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/hate1238/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/hate1238/md.ini
@@ -3,7 +3,6 @@
 name = Hateruma
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/hato1238/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/hato1238/md.ini
@@ -3,7 +3,6 @@
 name = Hatoma
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/ishi1240/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/ishi1240/md.ini
@@ -3,7 +3,6 @@
 name = Ishigaki
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/kabi1263/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/kabi1263/md.ini
@@ -3,7 +3,6 @@
 name = Kabira
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/koha1246/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/koha1246/md.ini
@@ -3,7 +3,6 @@
 name = Kohama
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/kuro1243/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/kuro1243/md.ini
@@ -3,7 +3,6 @@
 name = Kuroshima
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/shir1262/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/shir1262/md.ini
@@ -3,7 +3,6 @@
 name = Shiraho
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/sona1243/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/sona1243/md.ini
@@ -3,7 +3,6 @@
 name = Sonai
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/take1256/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/macr1267/yaey1239/take1256/md.ini
@@ -3,7 +3,6 @@
 name = Taketomi
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/cent2327/miya1260/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/cent2327/miya1260/md.ini
@@ -3,7 +3,6 @@
 name = Miyako-Jima
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/tara1319/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/tara1319/md.ini
@@ -3,7 +3,6 @@
 name = Tarama-Minna
 level = dialect
 macroareas = 
-	Papunesia
 countries = 
 
 [altnames]

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/taba1266/buen1245/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/taba1266/buen1245/md.ini
@@ -3,6 +3,5 @@
 name = Buena Vista Chontal
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/taba1266/mira1253/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/taba1266/mira1253/md.ini
@@ -3,6 +3,5 @@
 name = Miramar Chontal
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/taba1266/tamu1247/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/chol1287/chol1281/taba1266/tamu1247/md.ini
@@ -3,6 +3,5 @@
 name = Tamulté de las Sábanas Chontal
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzel1254/chan1320/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzel1254/chan1320/md.ini
@@ -3,6 +3,5 @@
 name = Chanal Cancuc
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzel1254/tena1239/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/chol1286/tzel1253/tzel1254/tena1239/md.ini
@@ -3,6 +3,5 @@
 name = Tenango
 level = dialect
 macroareas = 
-	South America
 countries = 
 

--- a/languoids/tree/maya1287/core1254/west2865/kanj1261/kanj1262/moch1257/moto1243/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/kanj1261/kanj1262/moch1257/moto1243/md.ini
@@ -3,7 +3,6 @@
 name = Motozintleco
 level = dialect
 macroareas = 
-	South America
 countries = 
 
 [altnames]

--- a/languoids/tree/maya1287/core1254/west2865/kanj1261/kanj1262/moch1257/tuza1238/md.ini
+++ b/languoids/tree/maya1287/core1254/west2865/kanj1261/kanj1262/moch1257/tuza1238/md.ini
@@ -3,6 +3,5 @@
 name = Tuzanteco
 level = dialect
 macroareas = 
-	South America
 countries = 
 


### PR DESCRIPTION
This PR simply removes the non-matching macroarea assignments - so the dialects will inherit the macroareas from their parent language.