### PR TITLE
Add alternative name “Sal”

### DIFF
--- a/languoids/tree/sino1245/brah1260/md.ini
+++ b/languoids/tree/sino1245/brah1260/md.ini
@@ -12,3 +12,6 @@ subrefs =
 	**hh:hv:vanDriem:Himalayas**
 	**hh:hv:Matisoff:Jingpho**
 
+[altnames]
+ethnologue =
+    Sal


### PR DESCRIPTION
Contrary to https://en.wikipedia.org/wiki/Sal_languages, the entry https://www.ethnologue.com/subgroups/sal actually exists, so I included that alternative name under `altnames>ethnologue`.