### PR TITLE
fix missing newline separator in source references

### DIFF
--- a/languoids/tree/bira1253/md.ini
+++ b/languoids/tree/bira1253/md.ini
@@ -87,7 +87,8 @@ endangeredlanguages = 4002
 
 [classification]
 familyrefs = 
-	**hh:ev:SavaThubauville:Ongota**:227-234 **hh:hv:Guldemann:Africa:Classification**:340-342
+	**hh:ev:SavaThubauville:Ongota**:227-234
+	**hh:hv:Guldemann:Africa:Classification**:340-342
 
 [endangerment]
 status = nearly extinct

--- a/languoids/tree/eski1264/md.ini
+++ b/languoids/tree/eski1264/md.ini
@@ -9,7 +9,8 @@ links =
 [classification]
 sub = **hh:hv:Dorais:Inuit**:1-54
 familyrefs = 
-	**hh:hv:Dorais:Inuit**:1-54 **hh:hv:Fortescue:Eskaleoutes**
+	**hh:hv:Dorais:Inuit**:1-54
+	**hh:hv:Fortescue:Eskaleoutes**
 	**hh:hv:Berge:Eskimo-Aleut:2018**
 subrefs = 
 	**hh:hv:Dorais:Inuit**


### PR DESCRIPTION
- cf. e.g. https://glottolog.org/resource/languoid/id/eski1264