### PR TITLE
fix inar1241 elcat altname delimiter issue

### DIFF
--- a/languoids/tree/ural1272/saam1281/east2324/main1280/inar1241/md.ini
+++ b/languoids/tree/ural1272/saam1281/east2324/main1280/inar1241/md.ini
@@ -126,8 +126,7 @@ hhbib_lgcode =
 	Inari Saami
 	Inari Sami
 elcat = 
-	"
-	"Inari Lappish
+	"Inari Lappish"
 	Anárašgiella
 	Enaresamisk
 	Enaresamiska


### PR DESCRIPTION
problem in the source: http://endangeredlanguages.com/lang/3431

not sure if we prefer to fix the source instead