### PR TITLE
normalize latitude/longitude float values to 12 decimal digits

### DIFF
--- a/languoids/tree/araw1281/nort2990/negr1239/wapi1252/mapi1252/md.ini
+++ b/languoids/tree/araw1281/nort2990/negr1239/wapi1252/mapi1252/md.ini
@@ -4,7 +4,7 @@ name = Mapidian-Mawayana
 hid = mpw
 level = language
 iso639-3 = mpw
-latitude = 1.9144999999999999
+latitude = 1.9145
 longitude = -59.6155
 macroareas = 
 	South America

--- a/languoids/tree/aust1307/mala1545/cent2237/cent2245/flor1240/flor1241/ngad1265/ngad1266/ngad1267/namu1249/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/cent2245/flor1240/flor1241/ngad1265/ngad1266/ngad1267/namu1249/md.ini
@@ -16,7 +16,6 @@ hhbib_lgcode =
 
 [classification]
 sub = p.c. Leif Asplund 2020
-subrefs = 
 
 [sources]
 glottolog = 

--- a/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/rhin1244/pala1355/penn1240/md.ini
+++ b/languoids/tree/indo1319/germ1287/nort3152/west2793/high1289/fran1268/high1287/rhin1244/pala1355/penn1240/md.ini
@@ -5,7 +5,7 @@ hid = pdc
 level = language
 iso639-3 = pdc
 latitude = 40.030507
-longitude = -76.32110
+longitude = -76.3211
 macroareas = 
 	North America
 countries = 

--- a/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/uncl1515/kurm1243/md.ini
+++ b/languoids/tree/indo1319/indo1320/indo1321/indo1323/oriy1254/gaud1237/gaud1238/uncl1515/kurm1243/md.ini
@@ -5,7 +5,7 @@ hid = kfv
 level = language
 iso639-3 = kfv
 latitude = 26.9175
-longitude = 87.32050000000001
+longitude = 87.3205
 macroareas = 
 	Eurasia
 countries = 

--- a/languoids/tree/indo1319/indo1320/iran1269/cent2317/sogd1247/sogd1248/khwa1238/md.ini
+++ b/languoids/tree/indo1319/indo1320/iran1269/cent2317/sogd1247/sogd1248/khwa1238/md.ini
@@ -20,11 +20,11 @@ glottolog =
 	**hh:d:BenzingTaraf:Chwaresmischer**
 	**hh:d:Henning:Khwarezmian**
 	**hh:d:MacKenzie:Khwarezmian**
+	**hh:ld:Henning:Khwarezmian**
 	**hh:ld:Henning:Khwarezmian-Verb**
 	**hh:s:Durkin-Meisterernst:Khwarezmian**
 	**hh:s:Edelman:Xorezmijskij**
 	**hh:s:Frejman:Xorezmijskij**
-	**hh:ld:Henning:Khwarezmian**
 	**hh:s:Humbach:Choresmian**
 	**hh:t:Benzing:Chwaresmische**
 	**hh:typ:Samadi:Chwaresmische**

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/ikem1234/irab1238/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/ikem1234/irab1238/md.ini
@@ -3,7 +3,7 @@
 name = Irabu-Jima
 level = dialect
 latitude = 24.831088
-longitude = 125.189560
+longitude = 125.18956
 macroareas = 
 	Eurasia
 countries = 

--- a/languoids/tree/kore1284/kore1280/kyon1247/md.ini
+++ b/languoids/tree/kore1284/kore1280/kyon1247/md.ini
@@ -2,8 +2,8 @@
 [core]
 name = Kyongsangdo
 level = dialect
-latitude = 35.30
-longitude = 128.30
+latitude = 35.3
+longitude = 128.3
 macroareas = 
 	Eurasia
 countries = 

--- a/languoids/tree/paho1240/agob1244/ende1235/md.ini
+++ b/languoids/tree/paho1240/agob1244/ende1235/md.ini
@@ -3,7 +3,7 @@
 name = Ende (Papua New Guinea)
 level = dialect
 latitude = -8.957786
-longitude = 142.24079900000004
+longitude = 142.240799
 macroareas = 
 	Papunesia
 countries = 

--- a/languoids/tree/sino1245/bodi1256/bodi1257/tsha1246/east1469/main1269/phob1238/chal1266/bumt1238/bumt1240/uraa1244/md.ini
+++ b/languoids/tree/sino1245/bodi1256/bodi1257/tsha1246/east1469/main1269/phob1238/chal1266/bumt1238/bumt1240/uraa1244/md.ini
@@ -5,6 +5,6 @@ level = dialect
 macroareas = 
 	Eurasia
 latitude = 27.466667
-longitude = 90.90
+longitude = 90.9
 countries = 
 

--- a/languoids/tree/sino1245/sini1245/minn1248/coas1318/minn1241/hokk1242/md.ini
+++ b/languoids/tree/sino1245/sini1245/minn1248/coas1318/minn1241/hokk1242/md.ini
@@ -2,7 +2,7 @@
 [core]
 name = Quanzhang
 level = dialect
-latitude = 24.994520
+latitude = 24.99452
 longitude = 118.597442
 macroareas = 
 	Eurasia

--- a/languoids/tree/turk1311/comm1245/cent2326/sout2693/saya1244/tuvi1240/md.ini
+++ b/languoids/tree/turk1311/comm1245/cent2326/sout2693/saya1244/tuvi1240/md.ini
@@ -4,7 +4,7 @@ name = Tuvinian
 hid = tyv
 level = language
 iso639-3 = tyv
-latitude = 51.70000
+latitude = 51.7
 longitude = 94.36667
 macroareas = 
 	Eurasia

--- a/languoids/tree/worr1236/ngar1284/guwi1238/md.ini
+++ b/languoids/tree/worr1236/ngar1284/guwi1238/md.ini
@@ -2,7 +2,7 @@
 [core]
 name = Guwidj
 level = dialect
-latitude = -15.10
+latitude = -15.1
 longitude = 126.5
 macroareas = 
 	Australia

--- a/languoids/tree/worr1236/ngar1284/woly1239/md.ini
+++ b/languoids/tree/worr1236/ngar1284/woly1239/md.ini
@@ -3,7 +3,7 @@
 name = Wolyamidi
 level = dialect
 latitude = -15.557223
-longitude = 126.221550
+longitude = 126.22155
 macroareas = 
 	Australia
 countries = 

--- a/languoids/tree/worr1236/west2435/worr1237/woro1258/md.ini
+++ b/languoids/tree/worr1236/west2435/worr1237/woro1258/md.ini
@@ -2,7 +2,7 @@
 [core]
 name = Worora
 level = dialect
-latitude = -15.824290
+latitude = -15.82429
 longitude = 125.155876
 countries = 
 	Australia (AU)


### PR DESCRIPTION
- simplify round-tripping
- go lower? (e.g. 4-8, see [Decimal_degrees](https://en.wikipedia.org/wiki/Decimal_degrees))