### PR TITLE
Fix location of Sangir

### DIFF
--- a/languoids/tree/aust1307/mala1545/sang1335/nort3174/nort2871/sang1336/md.ini
+++ b/languoids/tree/aust1307/mala1545/sang1335/nort3174/nort2871/sang1336/md.ini
@@ -4,8 +4,8 @@ name = Sangir
 hid = sxn
 level = language
 iso639-3 = sxn
-latitude = 5.444878
-longitude = 125.481047
+latitude = 3.000000
+longitude = 125.500000
 macroareas = 
 	Papunesia
 countries = 


### PR DESCRIPTION
Sangir and Sangil are currently both at the location of Sangil. This moves Sangir to the Sangihe Archipelago.