### PR TITLE
[ojib1241] Update md.ini for ISO639-1/2/3 [oj/oji]

### DIFF
--- a/languoids/tree/algi1248/algo1256/algo1257/east2765/ojib1240/ojib1241/md.ini
+++ b/languoids/tree/algi1248/algo1256/algo1257/east2765/ojib1240/ojib1241/md.ini
@@ -1,10 +1,38 @@
 # -*- coding: utf-8 -*-
 [core]
 name = Ojibwa
-level = family
+level = macrolanguage
+iso639-1 = oj
+iso639-2 = oji
+iso639-3 = oji
+macroareas = 
+	North America
+countries = 
+	Canada (CA)
+	United States (US)
 links = 
 	https://www.wikidata.org/entity/Q33875
 	https://en.wikipedia.org/wiki/Ojibwe_language
+
+[altnames]
+wals = 
+	Ojibwa
+multitree = 
+	Ojibwa
+	Ojibway
+	Ojibwe
+lexvo = 
+	Ojibwa language [en]
+	Ojibweg [br]
+	Ojibwa [en]
+hhbib_lgcode = 
+	Ojibwa
+elcat = 
+	Anishinaabemowin
+	Oji-Cree
+	Ojicree
+	Ojibwa
+	Ojibwe
 
 [classification]
 sub = **hh:hv:RhodesTodd:Subarctic-Algonquian**:62


### PR DESCRIPTION
this "family" is described in ISO 639-3 as a "macrolanguage", is also present in ISO 639-2, and has ISO639-1 code "oj".