### PR TITLE
Wikidata for Pollapese, better coordinates for Tenis language

### DIFF
--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/micr1243/micr1244/cent2276/west2844/pona1247/truk1243/nucl1749/cent2290/east2764/pulu1244/poll1238/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/micr1243/micr1244/cent2276/west2844/pona1247/truk1243/nucl1749/cent2290/east2764/pulu1244/poll1238/md.ini
@@ -9,6 +9,8 @@ macroareas =
 	Papunesia
 countries = 
 	Micronesia, Federated States of (FM)
+links = 
+	https://www.wikidata.org/entity/Q97164553
 
 [classification]
 sub = **hh:phon:Crippen:Pollapese:Sounds**:1

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/stma1240/teni1244/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/stma1240/teni1244/md.ini
@@ -4,8 +4,8 @@ name = Tenis
 hid = tns
 level = language
 iso639-3 = tns
-latitude = -2.71805
-longitude = 150.923
+latitude = -1.65074
+longitude = 150.672
 macroareas = 
 	Papunesia
 countries = 


### PR DESCRIPTION
- added wikidata for Pollapese
- moved coordinates for Tenis to Tench island (this language's homeland). The highest chance of meeting someone speaking Tenis is most probably on the island itself, despite a significant number of young Tench Islanders having moved to Kavieng. As Tench Island's children attend school on Mussau Island, they are more familiar with speaking Mussau-Emira than Tenis. In Kavieng there has been just one elder person having little grasp of Tenis language as of September 2006 
(Source: https://pnglanguages.sil.org/sites/png/files/tenis.pdf)
