### PR TITLE
Update md.ini

### DIFF
--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/micr1243/micr1244/cent2276/gilb1244/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/micr1243/micr1244/cent2276/gilb1244/md.ini
@@ -4,13 +4,15 @@ name = Gilbertese
 hid = gil
 level = language
 iso639-3 = gil
-latitude = -1.34
-longitude = 176.44
+latitude = 0.179
+longitude = 173.64
 macroareas = 
 	Papunesia
 countries = 
+	Fiji (FJ)
 	Kiribati (KI)
 	Solomon Islands (SB)
+	Tuvalu (TV)
 links = 
 	http://crubadan.org/languages/gil
 	https://en.wikipedia.org/wiki/Gilbertese_language


### PR DESCRIPTION
added Fiji (Rabi Island) and Tuvalu (Nui Atoll) with significant Gilbertese communities, placed coordinates further north at the main dialect boundary between northern and southern dialects