### PR TITLE
Update md.ini

### DIFF
--- a/languoids/tree/spee1234/indo1335/adur1234/md.ini
+++ b/languoids/tree/spee1234/indo1335/adur1234/md.ini
@@ -3,6 +3,8 @@
 name = Adurgari
 hid = NOCODE_Adurgari
 level = language
+latitude = 33.79
+longitude = 69.32
 macroareas = 
 	Eurasia
 countries = 


### PR DESCRIPTION
added coordinates, tribe named after Sheikh Mohammadi who is buried in the town of Zormat, nomadic traders travelling between Kabul, Jalalabad and the countryside. Source: http://shaikh-mohammadi.com/