### PR TITLE
Update md.ini for Tonga (Zambia) [toi]

### DIFF
--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/shon1250/core1255/ndau1241/tong1316/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/shon1250/core1255/ndau1241/tong1316/md.ini
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Tonga
+name = Tonga (Zambia)
 level = dialect
 macroareas = 
 	Africa
 countries = 
-
+	Zambia
+	Zimbabwe


### PR DESCRIPTION
Need disambiguation for Tonga. This one is the name of a dialect of an other language, and Tonga is also the name of several other Volta-Congo languages; also Tonga is the name of an unrelated country