### PR TITLE
fixed missing ISO codes

### DIFF
--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/cent2260/kong1295/kong1296/yaka1278/hung1280/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/cent2260/kong1295/kong1296/yaka1278/hung1280/md.ini
@@ -9,6 +9,7 @@ countries =
 	AO
 longitude = 18.192062
 latitude = -9.164628
+iso639-3 = hng
 
 [classification]
 sub = **hh:s:Atkins:Hungu**:163-164

--- a/languoids/tree/aust1307/mala1545/cent2237/cent2245/timo1260/west2945/wela1235/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/cent2245/timo1260/west2945/wela1235/md.ini
@@ -9,6 +9,7 @@ longitude = 125.239513
 latitude = -9.097288
 countries = 
 	TL
+iso639-3 = wlh
 
 [altnames]
 hhbib_lgcode = 

--- a/languoids/tree/indo1319/clas1257/balt1263/slav1255/sout3147/west2804/sout1528/chak1265/md.ini
+++ b/languoids/tree/indo1319/clas1257/balt1263/slav1255/sout3147/west2804/sout1528/chak1265/md.ini
@@ -9,6 +9,7 @@ links =
 	https://www.wikidata.org/entity/Q337565
 	https://en.wikipedia.org/wiki/Chakavian
 hid = ckm
+iso639-3 = ckm
 
 [altnames]
 multitree = 

--- a/languoids/tree/nilo1247/east2418/bari1283/nucl1796/kuku1285/md.ini
+++ b/languoids/tree/nilo1247/east2418/bari1283/nucl1796/kuku1285/md.ini
@@ -13,6 +13,7 @@ links =
 hid = ukv
 longitude = 31.537
 latitude = 3.9613
+iso639-3 = ukv
 
 [sources]
 glottolog = 

--- a/languoids/tree/nyul1248/east2381/unun9988/ngum1253/md.ini
+++ b/languoids/tree/nyul1248/east2381/unun9988/ngum1253/md.ini
@@ -13,6 +13,7 @@ links =
 	https://phoible.org/languages/ngum1253
 longitude = 122.230025
 latitude = -17.491239
+iso639-3 = xnm
 
 [classification]
 sub = **hh:hv:Bowern:Nyulnyulan-Jigsaw**

--- a/languoids/tree/sino1245/sini1245/clas1255/midd1354/yuep1234/ping1245/nort3268/md.ini
+++ b/languoids/tree/sino1245/sini1245/clas1255/midd1354/yuep1234/ping1245/nort3268/md.ini
@@ -11,6 +11,7 @@ macroareas =
 	Eurasia
 links = 
 	https://www.wikidata.org/entity/Q84302463
+iso639-3 = cnp
 
 [classification]
 sub = **hh:hv:Wang:Han**:117-118 **hh:hvtyp:deSousa:Nanning**:161-163 **hh:hv:deSousa:Pinghua**

--- a/languoids/tree/sino1245/sini1245/clas1255/midd1354/yuep1234/ping1245/sout3250/md.ini
+++ b/languoids/tree/sino1245/sini1245/clas1255/midd1354/yuep1234/ping1245/sout3250/md.ini
@@ -11,6 +11,7 @@ macroareas =
 	Eurasia
 links = 
 	https://www.wikidata.org/entity/Q84302019
+iso639-3 = csp
 
 [classification]
 sub = **hh:hv:Wang:Han**:117-118 **hh:hvtyp:deSousa:Nanning**:161-163 **hh:hv:deSousa:Pinghua**

--- a/languoids/tree/tuuu1241/huaa1247/lowe1407/md.ini
+++ b/languoids/tree/tuuu1241/huaa1247/lowe1407/md.ini
@@ -12,6 +12,7 @@ countries =
 links = 
 	https://www.wikidata.org/entity/Q6693681
 	https://en.wikipedia.org/wiki/Lower_Nossob_language
+iso639-3 = nsb
 
 [sources]
 glottolog = 


### PR DESCRIPTION
Fixed via
```python
from pyglottolog import Glottolog
api = Glottolog()
import re
iso = re.compile('[a-z]{3}')
for l in api.languoids():
    if iso.fullmatch(l.hid or '') and l.hid in api.iso:
        if not l.iso:
            l.iso = l.hid
            l.write_info()
```