### PR TITLE
Add location for San Juan Pueblo Tewa

### DIFF
--- a/languoids/tree/kiow1265/tewa1261/tewa1260/sanj1276/md.ini
+++ b/languoids/tree/kiow1265/tewa1261/tewa1260/sanj1276/md.ini
@@ -5,6 +5,9 @@ level = dialect
 macroareas = 
 	North America
 countries = 
+	US
+latitude = 36.0542
+longitude = -106.0703
 
 [sources]
 glottolog = 
@@ -13,3 +16,6 @@ glottolog =
 	**dplace:ortiz1969**
 	**dplace:parsons1929**
 
+[altnames]
+wals = 
+	Tewa (San Juan Pueblo)


### PR DESCRIPTION
This variety is now generally referred to Ohkay Owingeh Tewa, and is spoken in Ohkay Owingeh, New Mexico: https://en.wikipedia.org/wiki/Ohkay_Owingeh,_New_Mexico