### PR TITLE
add location for Tanpachoa

### DIFF
--- a/languoids/tree/uncl1493/tanp1235/md.ini
+++ b/languoids/tree/uncl1493/tanp1235/md.ini
@@ -3,6 +3,8 @@
 name = Tanpachoa
 hid = NOCODE_Tanpachoa
 level = language
+latitude = 31.759167
+longitude = -106.488611
 macroareas = 
 	North America
 countries = 


### PR DESCRIPTION
"In 1583–84 the Tanpachoa Indians were reported as living along the Rio Grande near the site of present El Paso."