### PR TITLE
drop empty altnames sections

### DIFF
--- a/languoids/tree/abkh1242/abkh1243/abaz1241/md.ini
+++ b/languoids/tree/abkh1242/abkh1243/abaz1241/md.ini
@@ -89,7 +89,6 @@ lexvo =
 	아바자어 [ko]
 hhbib_lgcode = 
 	Abkhazy north of the Caucasian ridge
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/afro1255/chad1250/east2632/east2633/bara1406/bare1279/md.ini
+++ b/languoids/tree/afro1255/chad1250/east2632/east2633/bara1406/bare1279/md.ini
@@ -45,7 +45,6 @@ hhbib_lgcode =
 	Giliya
 	Jalkiya
 	Komiya
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/araw1281/sout3131/puru1269/puru1265/inap1242/md.ini
+++ b/languoids/tree/araw1281/sout3131/puru1269/puru1265/inap1242/md.ini
@@ -28,7 +28,6 @@ hhbib_lgcode =
 	Pacaguara of Mercier via Nusser-Asport
 	Pacaguara-Mercier
 	Pacahuaras
-elcat = 
 
 [endangerment]
 status = nearly extinct

--- a/languoids/tree/atla1278/volt1241/kwav1236/nato1234/lele1262/likp1239/sekp1241/md.ini
+++ b/languoids/tree/atla1278/volt1241/kwav1236/nato1234/lele1262/likp1239/sekp1241/md.ini
@@ -47,7 +47,6 @@ lexvo =
 hhbib_lgcode = 
 	Likpe
 	Likpe-Sekpele
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/atla1278/volt1241/nort3149/buak1234/adam1257/goul1243/goul1244/zank1234/kula1285/fani1244/md.ini
+++ b/languoids/tree/atla1278/volt1241/nort3149/buak1234/adam1257/goul1243/goul1244/zank1234/kula1285/fani1244/md.ini
@@ -40,7 +40,6 @@ hhbib_lgcode =
 	Fanian
 	Kulaale
 	Mana
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cele1242/grea1299/east2488/sout2928/bung1268/east2489/east2490/baho1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/cele1242/grea1299/east2488/sout2928/bung1268/east2489/east2490/baho1237/md.ini
@@ -24,7 +24,6 @@ multitree =
 	Bahonsuái
 lexvo = 
 	Bahonsuai [en]
-elcat = 
 
 [identifier]
 multitree = bsu

--- a/languoids/tree/aust1307/mala1545/cele1242/grea1299/east2488/sout2928/muna1246/nucl1573/muni1256/buso1238/md.ini
+++ b/languoids/tree/aust1307/mala1545/cele1242/grea1299/east2488/sout2928/muna1246/nucl1573/muni1256/buso1238/md.ini
@@ -26,7 +26,6 @@ multitree =
 	Busoa
 lexvo = 
 	Busoa [en]
-elcat = 
 
 [identifier]
 multitree = bup

--- a/languoids/tree/aust1307/mala1545/cele1242/grea1299/tomi1242/sout2925/damp1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/cele1242/grea1299/tomi1242/sout2925/damp1237/md.ini
@@ -31,7 +31,6 @@ lexvo =
 	Dampelas [en]
 hhbib_lgcode = 
 	Dampelasa
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cele1242/kail1255/nort2898/kail1254/comm1248/bara1371/md.ini
+++ b/languoids/tree/aust1307/mala1545/cele1242/kail1255/nort2898/kail1254/comm1248/bara1371/md.ini
@@ -24,7 +24,6 @@ multitree =
 	Ende
 lexvo = 
 	Baras [en]
-elcat = 
 
 [identifier]
 multitree = brs

--- a/languoids/tree/aust1307/mala1545/cent2237/cent2245/cent2254/east2466/east2741/seti1249/beng1287/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/cent2245/cent2254/east2466/east2741/seti1249/beng1287/md.ini
@@ -42,7 +42,6 @@ hhbib_lgcode =
 	Kobi
 	Kobi-Benggoi
 	Lesa
-elcat = 
 
 [identifier]
 multitree = bgy

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/admi1239/east2459/manu1262/east2460/koro1314/bowa1234/papi1254/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/admi1239/east2459/manu1262/east2460/koro1314/bowa1234/papi1254/md.ini
@@ -31,7 +31,6 @@ lexvo =
 	Papitalai [en]
 hhbib_lgcode = 
 	Papitalai-Koro
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/admi1239/east2459/sout2879/loup1244/balu1257/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/admi1239/east2459/sout2879/loup1244/balu1257/md.ini
@@ -34,7 +34,6 @@ hhbib_lgcode =
 	Leut (Laut) auf Insel Paluan
 	Manus-Poam
 	Pam
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/sout3173/newc1243/main1286/sout3313/extr1245/nume1242/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/sout3173/newc1243/main1286/sout3313/extr1245/nume1242/md.ini
@@ -50,7 +50,6 @@ hhbib_lgcode =
 	Kwényi
 	Numèè
 	Île des Pins
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/sarm1241/sarm1242/anus1238/anus1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/ocea1241/west2818/nort3206/sarm1241/sarm1242/anus1238/anus1237/md.ini
@@ -39,7 +39,6 @@ lexvo =
 hhbib_lgcode = 
 	Korur
 	Sobei-Anus
-elcat = 
 
 [identifier]
 multitree = auq

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/bomb1263/bedo1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/bomb1263/bedo1237/md.ini
@@ -37,7 +37,6 @@ hhbib_lgcode =
 	Andamata
 	Forir
 	P 1677 Fioer
-elcat = 
 
 [identifier]
 multitree = bed

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/morm1235/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/morm1235/md.ini
@@ -52,7 +52,6 @@ hhbib_lgcode =
 	Mor (Ac)
 	Môr
 	Napan Weinami
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/raja1255/ambe1249/biga1238/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/raja1255/ambe1249/biga1238/md.ini
@@ -24,7 +24,6 @@ glottolog =
 [altnames]
 lexvo = 
 	Biga [en]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/raja1255/asss1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/cent2237/east2712/sout2850/sout3229/raja1255/asss1237/md.ini
@@ -28,7 +28,6 @@ lexvo =
 	As [en]
 hhbib_lgcode = 
 	Asbaken
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/cham1312/md.ini
+++ b/languoids/tree/aust1307/mala1545/cham1312/md.ini
@@ -134,7 +134,6 @@ lexvo =
 	チャモロ語 [ja]
 	查莫罗语 [zh]
 	차모로어 [ko]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/nort3238/meso1254/sout2905/md.ini
+++ b/languoids/tree/aust1307/mala1545/nort3238/meso1254/sout2905/md.ini
@@ -44,7 +44,6 @@ hhbib_lgcode =
 	Alta-Southern
 	Kabuloan
 	Negrito Máon
-elcat = 
 
 [identifier]
 multitree = agy

--- a/languoids/tree/aust1307/mala1545/nort3253/sara1342/puna1279/puna1280/aput1239/sian1255/md.ini
+++ b/languoids/tree/aust1307/mala1545/nort3253/sara1342/puna1279/puna1280/aput1239/sian1255/md.ini
@@ -41,7 +41,6 @@ glottolog =
 	Sian
 hhbib_lgcode = 
 	Sian
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/sout2923/nort2894/pitu1237/dakk1238/md.ini
+++ b/languoids/tree/aust1307/mala1545/sout2923/nort2894/pitu1237/dakk1238/md.ini
@@ -30,7 +30,6 @@ multitree =
 	Nordost-Celebes
 lexvo = 
 	Dakka [en]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/sout2923/ramp1244/bada1260/beso1237/md.ini
+++ b/languoids/tree/aust1307/mala1545/sout2923/ramp1244/bada1260/beso1237/md.ini
@@ -29,7 +29,6 @@ multitree =
 	Besoa
 lexvo = 
 	Besoa [en]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/aust1307/mala1545/sout2923/ramp1244/seko1241/pana1302/budo1241/md.ini
+++ b/languoids/tree/aust1307/mala1545/sout2923/ramp1244/seko1241/pana1302/budo1241/md.ini
@@ -32,7 +32,6 @@ lexvo =
 	Budong-Budong [en]
 hhbib_lgcode = 
 	Tangkou
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/coch1271/yuma1250/gene1244/paii1252/paip1241/md.ini
+++ b/languoids/tree/coch1271/yuma1250/gene1244/paii1252/paip1241/md.ini
@@ -40,7 +40,6 @@ lexvo =
 	Paipai [en]
 hhbib_lgcode = 
 	Akwa'ala of Gifford and Lowie 1928
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/geel1240/bura1294/bura1276/md.ini
+++ b/languoids/tree/geel1240/bura1294/bura1276/md.ini
@@ -24,7 +24,6 @@ multitree =
 	Burate
 lexvo = 
 	Burate [en]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/geel1240/demi1242/md.ini
+++ b/languoids/tree/geel1240/demi1242/md.ini
@@ -25,7 +25,6 @@ multitree =
 	Demisa
 lexvo = 
 	Demisa [en]
-elcat = 
 
 [identifier]
 multitree = dei

--- a/languoids/tree/inan1242/duri1243/md.ini
+++ b/languoids/tree/inan1242/duri1243/md.ini
@@ -29,7 +29,6 @@ multitree =
 	Sailen
 lexvo = 
 	Duriankere [en]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/indo1319/clas1257/indo1320/indo1321/indo1324/chit1278/kala1372/md.ini
+++ b/languoids/tree/indo1319/clas1257/indo1320/indo1321/indo1324/chit1278/kala1372/md.ini
@@ -67,7 +67,6 @@ hhbib_lgcode =
 	Kalasha
 	Kalashamon
 	Not Bashgali but Kalasha
-elcat = 
 glottolog = 
 	Kalasha
 

--- a/languoids/tree/iroq1247/nort2947/moha1257/moha1258/md.ini
+++ b/languoids/tree/iroq1247/nort2947/moha1257/moha1258/md.ini
@@ -93,7 +93,6 @@ lexvo =
 	모호크어 [ko]
 hhbib_lgcode = 
 	Iroquois Agnie
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/md.ini
+++ b/languoids/tree/japo1237/ryuk1243/ryuk1244/miya1259/md.ini
@@ -68,7 +68,6 @@ hhbib_lgcode =
 	Ogami
 	Tarama
 	Ōgami
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/kawe1237/nort1506/qawa1238/md.ini
+++ b/languoids/tree/kawe1237/nort1506/qawa1238/md.ini
@@ -213,7 +213,6 @@ hhbib_lgcode =
 	Kaueskar
 	Kawesqar
 	Latorre e Iriarte
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/lake1255/east2500/tawo1244/md.ini
+++ b/languoids/tree/lake1255/east2500/tawo1244/md.ini
@@ -39,7 +39,6 @@ hhbib_lgcode =
 	Dabra (Br)
 	Taria
 	Taworta (Ac)
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/lake1255/tari1255/east2502/dout1239/dout1240/md.ini
+++ b/languoids/tree/lake1255/tari1255/east2502/dout1239/dout1240/md.ini
@@ -43,7 +43,6 @@ lexvo =
 hhbib_lgcode = 
 	Taori So (Br)
 	Taori-So
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/nakh1245/dagh1238/avar1255/andi1254/botl1243/botl1242/md.ini
+++ b/languoids/tree/nakh1245/dagh1238/avar1255/andi1254/botl1243/botl1242/md.ini
@@ -35,7 +35,6 @@ lexvo =
 	Język botlichyjski [pl]
 	Ботлихский язык [ru]
 	Ботліська мова [uk]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/pama1250/dese1234/ngum1251/ngum1256/jaru1256/jaru1254/md.ini
+++ b/languoids/tree/pama1250/dese1234/ngum1251/ngum1256/jaru1256/jaru1254/md.ini
@@ -128,7 +128,6 @@ hhbib_lgcode =
 	Djäru
 	Nyininy
 	Wanyjirra closest to Djaru (not Gurinji)
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/sali1297/sali1298/md.ini
+++ b/languoids/tree/sali1297/sali1298/md.ini
@@ -115,7 +115,6 @@ hhbib_lgcode =
 	Saliba
 	Saliva
 	Sáliva
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/sape1238/md.ini
+++ b/languoids/tree/sape1238/md.ini
@@ -53,7 +53,6 @@ lexvo =
 	Сапески јазик [mk]
 hhbib_lgcode = 
 	Sape
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/sino1245/kuki1245/kuki1246/oldk1252/chir1298/chir1283/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/oldk1252/chir1298/chir1283/md.ini
@@ -29,7 +29,6 @@ multitree =
 	Tśiru
 lexvo = 
 	Chiru [en]
-elcat = 
 
 [identifier]
 multitree = cdf

--- a/languoids/tree/sino1245/mish1241/idum1241/md.ini
+++ b/languoids/tree/sino1245/mish1241/idum1241/md.ini
@@ -87,7 +87,6 @@ hhbib_lgcode =
 	Sulikata Mishmi
 	Yidu
 	Yidu Luoba
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/taik1256/kamt1241/daic1238/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/blac1269/thai1259/md.ini
+++ b/languoids/tree/taik1256/kamt1241/daic1238/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/blac1269/thai1259/md.ini
@@ -34,7 +34,6 @@ lexvo =
 	Thai Song [en]
 hhbib_lgcode = 
 	Tai Song
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/taik1256/kamt1241/daic1238/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/shan1276/assa1264/aito1238/md.ini
+++ b/languoids/tree/taik1256/kamt1241/daic1238/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/shan1276/assa1264/aito1238/md.ini
@@ -38,7 +38,6 @@ hhbib_lgcode =
 	Aitonias
 	Shan Aiton
 	Tai Aiton
-elcat = 
 
 [identifier]
 multitree = aio

--- a/languoids/tree/taik1256/kamt1241/daic1238/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/shan1276/assa1264/kham1290/md.ini
+++ b/languoids/tree/taik1256/kamt1241/daic1238/daic1237/cent2251/wenm1239/sapa1255/sout3184/sout2743/shan1276/assa1264/kham1290/md.ini
@@ -66,7 +66,6 @@ hhbib_lgcode =
 	Tai Khamti-Hukawng
 	Tai Khamti-Putao
 	Tai-Khamti
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/toro1256/tora1268/coas1312/bone1255/md.ini
+++ b/languoids/tree/toro1256/tora1268/coas1312/bone1255/md.ini
@@ -35,7 +35,6 @@ hhbib_lgcode =
 	Bonerif (Ac)
 	Edwas (Beneraf)
 	Edwas (Nengke)
-elcat = 
 
 [identifier]
 multitree = bnv

--- a/languoids/tree/tupi1275/mawe1252/awet1245/tupi1276/tupi1281/waya1271/zoee1241/zoee1240/md.ini
+++ b/languoids/tree/tupi1275/mawe1252/awet1245/tupi1276/tupi1281/waya1271/zoee1241/zoee1240/md.ini
@@ -54,7 +54,6 @@ lexvo =
 	Zoé [de]
 	Zoés [pt]
 	zoe [en]
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/tuuu1241/kwii1241/nuuu1241/md.ini
+++ b/languoids/tree/tuuu1241/kwii1241/nuuu1241/md.ini
@@ -47,7 +47,6 @@ hhbib_lgcode =
 	|=Khomani
 	||kx'au is Meinhof's Ungkwe mislabeled by Bleek
 	||ŋ
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/ural1272/saam1281/west2390/cent2240/nort2671/md.ini
+++ b/languoids/tree/ural1272/saam1281/west2390/cent2240/nort2671/md.ini
@@ -184,7 +184,6 @@ hhbib_lgcode =
 	Torne Lappish a subdialect of Norwegian Lappish
 	Tornädträsk
 	Čohkkiras
-elcat = 
 
 [triggers]
 lgcode = 

--- a/languoids/tree/west2604/kara1499/md.ini
+++ b/languoids/tree/west2604/kara1499/md.ini
@@ -37,7 +37,6 @@ lexvo =
 hhbib_lgcode = 
 	Karas
 	Karas (Ac)
-elcat = 
 
 [identifier]
 multitree = kgv;kars


### PR DESCRIPTION
via `treedb` roundtrip