### PR TITLE
[tll] is not correct for Tlapanec [mali1286]

### DIFF
--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/cent2260/nort3376/inne1246/vieu1234/nkut1239/tete1254/tete1250/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/cent2260/nort3376/inne1246/vieu1234/nkut1239/tete1254/tete1250/md.ini
@@ -211,9 +211,4 @@ subrefs =
 	**hh:hvw:Motingea:Nkutsu**
 	**hh:g:Jacobs:Tetela**
 
-[endangerment]
-status = threatened
-source = UNESCO
-date = 2017-08-19T22:02:46
-comment = Malinaltepec Tlapanec (698-tll) = Vulnerable
 


### PR DESCRIPTION
"tll" is the correct ISO 639-3 language code for [tete1250] "Tetela" (a Nkutsuic language, part of Narrow Bantu languages, spoken in Congo DRC.)

But "tll" is NOT an ISO 639-3 language code for the [mali1286] "Tlapanec" dialect of ISO639-3's [tcf] "Malinaltepec Me'phaa" (a Mesoamerican language spoken in Central Mexico).

Remove these lines from [tete1250/md.ini]:

[altnames]
multitree = 
```
	Tlapaneco malinaltepeco
	Tlapanèque de Malinaltepec
```

and

```
[endangerment]
status = threatened
source = UNESCO
date = 2017-08-19T22:02:46
comment = Malinaltepec Tlapanec (698-tll) = Vulnerable
```
(error in processing the UNESCO source "comment" line?)

These lines, related to the [mali1286] "Tlapanec" dialect of [tcf] "Malinaltepec Me'phaa",  have to be moved elsewhere, in [mali1286/md.ini]
