### PR TITLE
acy as an independent language

### DIFF
--- a/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/leva1239/cypr1248/md.ini
+++ b/languoids/tree/afro1255/semi1276/west2786/cent2236/arab1394/arab1395/leva1239/cypr1248/md.ini
@@ -86,9 +86,10 @@ multitree = acy
 endangeredlanguages = 3177
 
 [classification]
-sub = **hh:hv:Naim:Levant**
+sub = **hh:hv:Al-Jallad:Neo-Arabic** **hh:hvb:Watson:Arabic-Dialects**
 subrefs = 
-	**hh:hv:Naim:Levant**
+	**hh:hv:Al-Jallad:Neo-Arabic**
+	**hh:hvb:Watson:Arabic-Dialects**
 
 [endangerment]
 status = shifting


### PR DESCRIPTION
Cypriot Arabic used to be considered a Levantine dialect.

Nowadays, most sources I found consider it as a separate variety. For instance _Ethnologue_: "A hybrid language with roots in the Arabic of both Anatolia and Levant. Many borrowings from Syriac [[syc]](https://www.ethnologue.com/language/syc) and Greek [[ell]](https://www.ethnologue.com/language/ell)." ([source](https://www.ethnologue.com/language/acy))

For a similar opinion, see also: Borg, Alexander (2011). "Cypriot Maronite Arabic". In Edzard, Lutz; de Jong, Rudolf (eds.). Encyclopedia of Arabic Language and Linguistics. Brill. [doi](https://en.wikipedia.org/wiki/Doi_(identifier)):[10.1163/1570-6699_eall_EALL_COM_0076](https://doi.org/10.1163%2F1570-6699_eall_EALL_COM_0076).