### PR TITLE
Update md.ini (Yola classification)

### DIFF
--- a/languoids/tree/indo1319/clas1257/germ1287/nort3152/west2793/nort3175/angl1264/angl1265/late1254/merc1242/macr1271/stan1293/iris1255/sout3298/east2834/yola1237/md.ini
+++ b/languoids/tree/indo1319/clas1257/germ1287/nort3152/west2793/nort3175/angl1264/angl1265/late1254/merc1242/macr1271/stan1293/iris1255/sout3298/east2834/yola1237/md.ini
@@ -2,7 +2,7 @@
 [core]
 name = Yola
 hid = yol
-level = dialect
+level = language
 iso639-3 = yol
 macroareas = 
 	Eurasia
@@ -10,7 +10,7 @@ countries =
 	IE
 links = 
 	http://crubadan.org/languages/yol
-	https://en.wikipedia.org/wiki/Forth_and_Bargy_dialect
+	https://en.wikipedia.org/wiki/Yola_(language)
 	https://www.wikidata.org/entity/Q56395
 
 [sources]
@@ -29,3 +29,7 @@ lexvo =
 	Йола [ru]
 	욜라어 [ko]
 
+[classification]
+sub = **hh:hv:Hogg:Old-English**
+subrefs = 
+	**hh:hv:Hogg:Old-English**


### PR DESCRIPTION
Yola is recognized as an Anglic language, a sister language of Scots and Modern English. I'm not very familiar with github so please let me know if I made any mistakes in trying to correct the classification, I also updated the wikipedia source from the redirect to the article title instead.