### PR TITLE
Update md.ini

### DIFF
--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/sabi1248/nsen1242/kund1254/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/sabi1248/nsen1242/kund1254/md.ini
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Kunda, Akunda
+name = Kunda
 level = dialect
 macroareas = 
 	Africa
-countries = Zambia
-Province = Eastern
-District = Mambwe
+countries = 
+	ZM
+
+[altnames]
+glottolog = 
+	Akunda
+	Kunda of Mambwe district in Eastern Province of Zambia
+

--- a/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/sabi1248/nsen1242/kund1254/md.ini
+++ b/languoids/tree/atla1278/volt1241/benu1247/bant1294/sout3152/narr1281/east2731/sabi1248/nsen1242/kund1254/md.ini
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Kunda
+name = Kunda, Akunda
 level = dialect
 macroareas = 
 	Africa
-countries = 
-
+countries = Zambia
+Province = Eastern
+District = Mambwe


### PR DESCRIPTION
The Kunda people of Eastern Province of Zambia, are often confused with the Chikunda people found in Luangwa, Lusaka Province of Zambia and also in Mozambique and Zimbabwe.