### PR TITLE
Changed Faetar dialect link to Faetar language

### DIFF
--- a/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/fran1269/faet1240/md.ini
+++ b/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/fran1269/faet1240/md.ini
@@ -9,7 +9,7 @@ countries =
 	IT
 links = 
 	https://www.wikidata.org/entity/Q3064408
-	https://en.wikipedia.org/wiki/Faetar_dialect
+	https://en.wikipedia.org/wiki/Faetar_language
 longitude = 15.171636
 latitude = 41.32435
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Faetar_dialect now redirects to https://en.wikipedia.org/wiki/Faetar_language