### PR TITLE
Removed links to Louisiana French from Gulf Coast French languoid

### DIFF
--- a/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/gulf1242/md.ini
+++ b/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/circ1240/gulf1242/md.ini
@@ -7,9 +7,6 @@ macroareas =
 	North America
 countries = 
 	US
-links = 
-	https://www.wikidata.org/entity/Q3083213
-	https://en.wikipedia.org/wiki/Louisiana_French
 longitude = -89.268008
 latitude = 30.379584
 


### PR DESCRIPTION
The source used for this entry says that Gulf Coast French isn't a variety of Louisiana French. I checked the edit history of the Louisiana French article on Wikipedia and a link to the Gulf Coast French Glottolog entry was added before the links to Wikipedia and Wikidata's Louisiana French articles were added to the Gulf Coast French languoid. It is purely citogenesis.