### PR TITLE
Update md.ini

### DIFF
--- a/languoids/tree/aust1307/mala1545/mala1536/sund1251/sund1252/cire1239/md.ini
+++ b/languoids/tree/aust1307/mala1545/mala1536/sund1251/sund1252/cire1239/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Mid-East Sundanese
+name = Cirebon Sundanese
 level = dialect
 macroareas = 
 	Papunesia


### PR DESCRIPTION
I think this is a more appropriate naming, because "Mid-East Sundanese" only refers to "Majalengka Sundanese".