### PR TITLE
drop empty arub1238 subrefs

### DIFF
--- a/languoids/tree/araw1281/cari1281/anti1247/uncl1528/arub1238/md.ini
+++ b/languoids/tree/araw1281/cari1281/anti1247/uncl1528/arub1238/md.ini
@@ -45,5 +45,4 @@ glottolog =
 
 [classification]
 sub = p.c. Lev Michael and Andrés Sabogal 2020
-subrefs = 
 


### PR DESCRIPTION
- redo #905
- to fast-forward merge into release-4.7-bis