### PR TITLE
restore diacritics in Alfold and Csango

### DIFF
--- a/languoids/tree/ural1272/hung1287/hung1274/alfo1240/md.ini
+++ b/languoids/tree/ural1272/hung1287/hung1274/alfo1240/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Alfold
+name = Alföld
 level = dialect
 macroareas = 
 	Eurasia
@@ -8,7 +8,6 @@ countries =
 
 [altnames]
 multitree = 
-	Alfold
 	Alföld
 	Alfölder Mundartgebiet
 

--- a/languoids/tree/ural1272/hung1287/hung1274/csan1238/md.ini
+++ b/languoids/tree/ural1272/hung1287/hung1274/csan1238/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Csango
+name = Csángó
 level = dialect
 macroareas = 
 	Eurasia
@@ -8,7 +8,6 @@ countries =
 
 [altnames]
 multitree = 
-	Csango
 	Csángó
 	Csángó-Mundart
 


### PR DESCRIPTION
The correct spelling of the Hungarian dialects [Alföld](https://en.wikipedia.org/wiki/Great_Hungarian_Plain) and [Csángó](https://en.wikipedia.org/wiki/Cs%C3%A1ng%C3%B3s) was listed only in the alternative names. I don't see a reason why the diacritics should be cut off here.