### PR TITLE
Add Wikipedia link for Western Maithili/Bajjika

### DIFF
--- a/languoids/tree/indo1319/clas1257/indo1320/indo1321/midd1375/cont1248/midl1245/shau1239/biha1245/mait1254/mait1250/west2380/md.ini
+++ b/languoids/tree/indo1319/clas1257/indo1320/indo1321/midd1375/cont1248/midl1245/shau1239/biha1245/mait1254/mait1250/west2380/md.ini
@@ -5,7 +5,8 @@ level = dialect
 macroareas = 
 	Eurasia
 countries = 
-
+links =
+	https://en.wikipedia.org/wiki/Bajjika
 [altnames]
 multitree = 
 	Western Maithili


### PR DESCRIPTION
Wikipedia links Bajjika to Western Maithili. If that information is correct, it would make sense for the linking to be also on Glottolog website?