### PR TITLE
Istro Romanian -> Istro-Romanian; Megleno Romanian -> Megleno-Romanian

### DIFF
--- a/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/east2714/nort3361/east2865/megl1237/md.ini
+++ b/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/east2714/nort3361/east2865/megl1237/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Megleno Romanian
+name = Megleno-Romanian
 hid = ruq
 level = language
 iso639-3 = ruq

--- a/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/east2714/nort3361/istr1245/md.ini
+++ b/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/east2714/nort3361/istr1245/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Istro Romanian
+name = Istro-Romanian
 hid = ruo
 level = language
 iso639-3 = ruo


### PR DESCRIPTION
"Istro" and "Megleno" are combining forms, not independent words.