### PR TITLE
add SM as country in md.ini for Romagnol

### DIFF
--- a/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1279/emil1243/roma1328/md.ini
+++ b/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1279/emil1243/roma1328/md.ini
@@ -10,6 +10,7 @@ macroareas =
 	Eurasia
 countries = 
 	IT
+ 	SM
 links = 
 	[Romagnol](https://endangeredlanguages.com/lang/3206)
 	https://en.wikipedia.org/wiki/Romagnol_dialects


### PR DESCRIPTION
Romagnol is spoken not only in Italy but also in San Marino (specifically the Sammarinese dialect)