### PR TITLE
Prioritize native language name when possible

### DIFF
--- a/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/glob1239/stan1290/md.ini
+++ b/languoids/tree/indo1319/clas1257/ital1284/lati1262/lati1263/impe1234/roma1334/ital1285/west2813/shif1234/nort3208/gall1280/oila1234/cent2283/macr1273/glob1239/stan1290/md.ini
@@ -990,6 +990,7 @@ glottolog =
 	**wals:879**
 
 [altnames]
+-Native- = français 
 wals = 
 	French
 ruhlen (1987) = 


### PR DESCRIPTION
Instead of digging through the "Alternative names" category trying to match a code, the native name of a language (if it exists) should be given priority. 

I think that a native name deserves more than being at the top of the alternative names, but that change would require a new spot on the webpage, so I'd rather hear what the community/leadership thinks about the general idea first. I'm not saying "français" should replace "French" as stan1290's title (I understand the reasons behind "French" being the choice), but I do think it deserves a subheading.

Setting an example, I guess this page is a good source for "français" being correct: 
https://www.academie-francaise.fr/la-langue-francaise/terminologie