### PR TITLE
Fixing map coordinates for Wancho

### DIFF
--- a/languoids/tree/sino1245/brah1260/kony1246/kony1247/sout3407/wanc1241/wanc1238/md.ini
+++ b/languoids/tree/sino1245/brah1260/kony1246/kony1247/sout3407/wanc1241/wanc1238/md.ini
@@ -4,8 +4,8 @@ name = Wancho Naga
 hid = nnp
 level = language
 iso639-3 = nnp
-latitude = 26.2581
-longitude = 94.8936
+latitude = 26.8873
+longitude = 95.3203
 macroareas = 
 	Eurasia
 countries = 


### PR DESCRIPTION
Fixing an incorrect location for Wancho, putting it much too far south from where it's actually spoken. Changed the location to Longding, being the HQ of the district where it is spoken and which is centrally located in that district.