### PR TITLE
Updated coordinates for Gubeeher-Gufangor-Gubelor

### DIFF
--- a/languoids/tree/atla1278/nort3146/wolo1248/east2703/bain1264/gube1234/md.ini
+++ b/languoids/tree/atla1278/nort3146/wolo1248/east2703/bain1264/gube1234/md.ini
@@ -7,8 +7,8 @@ macroareas =
 	Africa
 countries = 
 	SN
-longitude = -17.19
-latitude = 12.56
+longitude = -16.352752
+latitude = 12.526764
 links = 
 	[Baïnounk Gubëeher](https://endangeredlanguages.com/lang/1418)
 	[Gubeeher-Gufangor-Gubelor](https://grambank.clld.org/languages/gube1234)


### PR DESCRIPTION
The current coordinate is in the Atlantic.
The corresponding language in ElCat (https://endangeredlanguages.com/lang/1418) is described as follows:

> It is spoken in the village of Djibonker, 13km to the west of the regional
> capital Ziguinchor, on the road to Cape Skirring.

The coordinate proposed here follows this description.