### PR TITLE
Remove SB from country list

### DIFF
--- a/languoids/tree/aust1307/mala1545/mina1272/tons1239/md.ini
+++ b/languoids/tree/aust1307/mala1545/mina1272/tons1239/md.ini
@@ -10,7 +10,6 @@ macroareas =
 	Papunesia
 countries = 
 	ID
-	SB
 links = 
 	[Tonsawang](https://endangeredlanguages.com/lang/3524)
 	https://www.wikidata.org/entity/Q3531660


### PR DESCRIPTION
I does not seem likely that Tonsawang is also spoken in the Solomons. https://glottolog.org/glottolog/language.map.html?country=SB