### PR TITLE
Add ISO code for Interslavic

### DIFF
--- a/languoids/tree/arti1236/inte1263/md.ini
+++ b/languoids/tree/arti1236/inte1263/md.ini
@@ -2,7 +2,8 @@
 [core]
 name = Interslavic zonal constructed language
 level = language
-hid = NOCODE_Interslavic-Zonal
+hid = isv
+iso639-3 = isv
 countries = 
 	CZ
 links = 


### PR DESCRIPTION
Interslavic has recently received an ISO 639-3 code.