### PR TITLE
Remove "(Keapara)" from Kalo dialect name

### DIFF
--- a/languoids/tree/aust1307/mala1545/east2712/ocea1241/west2818/papu1253/peri1258/cent2070/sina1272/hula1245/keap1239/kalo1259/md.ini
+++ b/languoids/tree/aust1307/mala1545/east2712/ocea1241/west2818/papu1253/peri1258/cent2070/sina1272/hula1245/keap1239/kalo1259/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Kalo (Keapara)
+name = Kalo
 level = dialect
 macroareas = 
 	Papunesia


### PR DESCRIPTION
This pull request proposes the removal of "(Keapara)" from the `name` field of the Kalo dialect in the `md.ini` file.
 Rationale:
- Individual Village Representation: Kalo is an individual village, similar to Babga, Kapari, Lalaura, and Maopa, each of which does not have "Keapara" in brackets.
- Accurate Naming: The name Keapara comes from a sister village and bears no significance to the Kalo dialect.
- Historical Context: The current naming convention was based on Dutton's decision for convenience, but it does not accurately represent the unique identity of the Kalo village.
- 
Personal Note:
I am a native of the Kalo village, and I believe this change is important for accurately representing our dialect and maintaining consistency across all sister villages.