### PR TITLE
order biaf1240 glottolog names and normalize

### DIFF
--- a/languoids/tree/atla1278/nort3146/jaad1234/biaf1240/md.ini
+++ b/languoids/tree/atla1278/nort3146/jaad1234/biaf1240/md.ini
@@ -105,12 +105,10 @@ elcat =
 	Bidyola
 	Fada
 	Ganjoola
-
 glottolog = 
-	Yola
 	Joolaa
 	Njoola
-
+	Yola
 
 [triggers]
 lgcode = 


### PR DESCRIPTION
- follow-up to c79ed280d1ca998b7a3f3277347a72094df380df