### PR TITLE
Add ISO language code for Salish

### DIFF
--- a/languoids/tree/sali1255/md.ini
+++ b/languoids/tree/sali1255/md.ini
@@ -2,6 +2,7 @@
 [core]
 name = Salishan
 level = family
+iso639-3 = sal
 links = 
 	https://www.wikidata.org/entity/Q33985
 	https://en.wikipedia.org/wiki/Salishan_languages


### PR DESCRIPTION
As per https://iso639-3.sil.org/code/sal `sal` is the language code for Salishan languages.