### PR TITLE
Update md.ini

### DIFF
--- a/languoids/tree/sino1245/kuki1245/kuki1246/cent2330/mara1381/nucl1757/mara1382/hlaw1238/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/cent2330/mara1381/nucl1757/mara1382/hlaw1238/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Hlawthai
+name = Hawthai
 level = dialect
 macroareas = 
 	Eurasia
@@ -9,7 +9,6 @@ countries =
 [altnames]
 multitree = 
 	Hawthai
-	Hlawthai
 
 [identifier]
 multitree = mrh-hla


### PR DESCRIPTION
The dialect name "Hlawthai" is not there in Mara language family. It is "Hawthai". So, please approve my updates.