### PR TITLE
Rename 'Hlawthai' to 'Hawthai' in md.ini

### DIFF
--- a/languoids/tree/sino1245/kuki1245/kuki1246/cent2330/mara1381/nucl1757/mara1382/hlaw1238/md.ini
+++ b/languoids/tree/sino1245/kuki1245/kuki1246/cent2330/mara1381/nucl1757/mara1382/hlaw1238/md.ini
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 [core]
-name = Hlawthai
+name = Hawthai
 level = dialect
 macroareas = 
 	Eurasia


### PR DESCRIPTION
"Hlawthai" is an incorrect name that we have never used. The correct name is "Hawthai", so it has been updated accordingly.